### PR TITLE
blinker appears to require requests==1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
                 'MongoEngine>=0.7.999',
                 'Mako>=0.4.1',
                 'beaker>=1.5',
-                'requests',
+                'requests==1.1.0',
                 'blinker',
                 'pyyaml',
                 'ecdsa',


### PR DESCRIPTION
One of my few lingering speed bumps in getting a dev install running
