### PR TITLE
Add Shallow API Key Validation

### DIFF
--- a/adam/auth/controller/key.py
+++ b/adam/auth/controller/key.py
@@ -44,10 +44,13 @@ class KeyList(HTTPMethod):
         data = Bunch(kw)
 
         record = EVECredential(data.key, data.code, owner=user.id)
-        record.save()
-
-        if request.is_xhr:
-            return 'json:', {'success': True, 'identifier': str(record.id), 'key': record.key, 'code': record.code}
+        try:
+            record.save()
+            if request.is_xhr:
+                return 'json:', {'success': True, 'identifier': str(record.id), 'key': record.key, 'code': record.code}
+        except ValidationError:
+            if request.is_xhr:
+                return 'json:', {'success': False, 'message': 'Validation error for Eve Credential: One or more fields are incorrect or missing'}
 
         raise HTTPFound(location='/key/')
 

--- a/adam/auth/template/key/list.html
+++ b/adam/auth/template/key/list.html
@@ -85,8 +85,8 @@
 						'<strong>Note:</strong> At no point are services given direct access to your API key.  Any API access a service ' +
 						'requests must be explicitly granted by you at the time you register for the service.' +
 						'<form>' +
-							'<input name="key" type="text" class="input-block-level" placeholder="Key ID">' +
-							'<input name="code" type="text" class="input-block-level" placeholder="Verification Code">' +
+							'<input name="key" type="text" class="input-block-level" placeholder="Key ID" pattern="^\\d+$" maxlength="8">' +
+							'<input name="code" type="text" class="input-block-level" placeholder="Verification Code" maxlength="64">' +
 						'</form>' +
 					'</p>',
 					{
@@ -95,6 +95,15 @@
 					},
 					function()
 					{
+						$('#modal form .alert').remove();
+						if (!/\d+/.test($('#modal form input[name="key"]').val())) {
+							errors = true;
+							$('#modal form input[name="key"]').after(
+								'<div class="alert alert-error">' +
+									'<strong>Key ID must be a number</strong>'
+							);
+							return true;
+						}
 						$.post('/key/', $('#modal form').serialize(), function(data)
 						{
 							console.log(data);


### PR DESCRIPTION
Client-side submission will trigger a check of the length and
integer value of the API Key ID. Additionally, limits of
8 and 64 characters have been added for the Key ID and Verification
Code (respectively)

See issue #21
