### PR TITLE
Added password length check for 'password change' in settings for consistency.

### DIFF
--- a/brave/core/account/template/settings.html
+++ b/brave/core/account/template/settings.html
@@ -112,6 +112,17 @@
                     {
                         $('#modal form .alert').remove();
                         error = false;
+			if ( $('#new-pass').val().length >= 100 ) {
+                            $('#new-pass').addClass('error');
+                            $('#new-pass').focus()
+                            $('#modal form input[name="passwd"]').after(
+                                '<div class="alert alert-error">' +
+                                    '<strong>Passwords must not be longer than 100 characters</strong>' +
+                                '</div>'
+                            );
+                            error = true
+                        }
+
                         if ( $('#new-pass-confirm').val() !=  $('#new-pass').val()) {
                             $('#new-pass-confirm').addClass('error');
                             $('#new-pass-confirm').focus()


### PR DESCRIPTION
Quick update for consistency.
On sign up users are limited to a password of 100 chars.

Changes made to keep this limitation when users go to change their password from the settings screen.
