### PR TITLE
Fix exception & make refresh inline when adding keys

### DIFF
--- a/brave/core/key/controller.py
+++ b/brave/core/key/controller.py
@@ -87,6 +87,11 @@ class KeyList(HTTPMethod):
         
         try:
             record.save()
+            record.pull()
+            characters = []
+            for character in record.characters:
+                characters.append(dict(identifier = character.identifier, name = character.name))
+
             if request.is_xhr:
                 return 'json:', dict(
                         success = True,
@@ -94,6 +99,7 @@ class KeyList(HTTPMethod):
                         identifier = str(record.id),
                         key = record.key,
                         code = record.code,
+                        characters = characters
                     )
         
         except ValidationError:

--- a/brave/core/key/template/list.html
+++ b/brave/core/key/template/list.html
@@ -74,7 +74,11 @@
                                         '<span class="ellipsis">' + data.code + '</span>' +
                                     '</td>' +
                                     '<td class="characters hidden-tablet hidden-phone">' +
-                                        '<img src="" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="">Refresh to view' +
+                                        data.characters.map( function(element) {
+                                            return( '<img src="http://image.eveonline.com/Character/' + element.identifier + '_32.jpg" ' +
+                                                'style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; ' +
+                                                'height: 24px;" title="' + element.name + '">' );
+                                        }).join( '\n' ) +
                                     '</td>' +
                                     '<td class="key-date  hidden-phone">' +
                                         '<time datetime="'+new Date().toISOString()+'">just now</time>' +

--- a/brave/core/util/signal.py
+++ b/brave/core/util/signal.py
@@ -61,9 +61,9 @@ def validate_key(identifier):
     
     result = APICall.objects.get(name='account.APIKeyInfo')(cred)
     
-    cred.mask = int(result.key['@accessMask'])
-    cred.kind = result.key['@type']
-    cred.expires = datetime.strptime(result.key['@expires'], '%Y-%m-%d %H:%M:%S') if result.key.get('@expires', None) else None
+    cred.mask = int(result['accessMask'])
+    cred.kind = result['type']
+    cred.expires = datetime.strptime(result['expires'], '%Y-%m-%d %H:%M:%S') if result.get('expires', None) else None
     cred.verified = cred.mask != 0
     cred.save()
     


### PR DESCRIPTION
When adding a key an exception due to dereferencing a key not in the
bunch is thrown, this has been fixed.

Also make refreshing unnecessary by pulling API details inline.
