### PR TITLE
Always write the character alliance field

### DIFF
--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -103,7 +103,7 @@ class EVECredential(Document):
         char.name = info.characterName if 'characterName' in info else info.name
         char.corporation = corporation
         
-        if alliance: char.alliance = alliance
+        char.alliance = alliance
         
         return char.save(), corporation, alliance
     


### PR DESCRIPTION
The character might have left a previous alliance, and we want to clear
the field.
