### PR TITLE
Fix dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ python:
 services:
   - mongodb
 install:
-  - pip install git+https://github.com/marrow/marrow.templating.git@develop#egg=marrow.templating
-  - pip install git+https://github.com/marrow/marrow.tags.git@develop#egg=marrow.tags
-  - pip install nose coverage webtest
-  - pip install . --use-mirrors
+  - pip install -r requirements.txt . --use-mirrors
 script: python setup.py test
 

--- a/README.textile
+++ b/README.textile
@@ -37,23 +37,12 @@ Once you have this, enter and activate the virtual environment:
 <pre><code>cd brave
 source bin/activate</code></pre>
 
-Now bootstrap the web framework:
-
-<pre><code>pip install WebCore</code></pre>
-
-Additionally, there are some requirements you will need to manually install as Core Services require features present in as-yet unreleased packages.  You will need to perform the following steps:
-
-<pre><code>(git clone https://github.com/marrow/marrow.templating.git; cd marrow.templating; python setup.py develop)
-(git clone https://github.com/marrow/marrow.tags.git; cd marrow.tags; python setup.py develop)
-(git clone https://github.com/bravecollective/api.git; cd api; python setup.py develop)
-(git clone https://github.com/dropbox/python-zxcvbn.git; cd python-zxcvbn; python setup.py install)</code></pre>
-
 Installing the current development version of the Core Service requires "Git":git, a distributed source code management system.  Compilation additionally requires the Python development headers and the OpenSSL development headers.  In Debian/Ubuntu, these are found in packages `python-dev` and `libssl-dev`.
 Run the following to download the development version with Git, and _link_ it into your Python runtime:
 
 <pre><code>git clone https://github.com/bravecollective/core.git
 cd core
-python setup.py develop</code></pre>
+pip install -r requirements.txt -e .</code></pre>
 
 Once you have successfully compiled the Core Service, copy `development.ini` to `local.ini`, and make changes as appropriate.  Finally, bootstrap the EVE API system by running:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# keep in sync with dependency_links in setup.py (sadness).
+https://github.com/marrow/marrow.tags/archive/develop.zip#egg=marrow.tags
+https://github.com/marrow/marrow.templating/archive/develop.zip#egg=marrow.templating
+https://github.com/marrow/WebCore/archive/develop.zip#egg=WebCore
+https://github.com/bravecollective/api/archive/develop.zip#egg=brave.api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# keep in sync with dependency_links in setup.py (sadness).
 https://github.com/marrow/marrow.tags/archive/develop.zip#egg=marrow.tags
 https://github.com/marrow/marrow.templating/archive/develop.zip#egg=marrow.templating
 https://github.com/marrow/WebCore/archive/develop.zip#egg=WebCore

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,6 @@ setup(
         tests_require = ['nose', 'webtest', 'coverage'],
         test_suite = 'nose.collector',
         
-        # keep in sync with requirements.txt (sadness).
-        dependency_links = [
-            'https://github.com/marrow/marrow.tags/archive/develop.zip#egg=marrow.tags',
-            'https://github.com/marrow/marrow.templating/archive/develop.zip#egg=marrow.templating',
-            'https://github.com/marrow/WebCore/archive/develop.zip#egg=WebCore',
-            'https://github.com/bravecollective/api/archive/develop.zip#egg=brave.api',
-        ],
-        
         install_requires = [
                 'requests==1.1.0',
                 'marrow.tags',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys, os
 from setuptools import setup, find_packages
 
 setup(
-        name = "Brave Core Services",
+        name = "brave.core",
         version = "0.1",
         description = "EVE Online authentication, authorization, and API proxy service.",
         author = "Alice Bevan-McGregor",
@@ -20,6 +20,7 @@ setup(
         tests_require = ['nose', 'webtest', 'coverage'],
         test_suite = 'nose.collector',
         
+        # keep in sync with requirements.txt (sadness).
         dependency_links = [
             'https://github.com/marrow/marrow.tags/archive/develop.zip#egg=marrow.tags',
             'https://github.com/marrow/marrow.templating/archive/develop.zip#egg=marrow.templating',

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
                 'marrow.mailer',
                 'yubico',
                 'futures',
+                'zxcvbn',
             ],
         
     )


### PR DESCRIPTION
- add zxcvbn as python dependency
- use pip in installation instructions

This is going to fail the build; however, 5c3d5295aa5224bd06458cd7a02bab71399ad2c6, which is this but aimed at a fixed version of the API repo, passes (https://travis-ci.org/eve-val/core/builds/23661270)
