### PR TITLE
Let enter submit more forms

### DIFF
--- a/brave/core/account/form.py
+++ b/brave/core/account/form.py
@@ -38,6 +38,7 @@ register = Form('register', action='/account/register', method='post', children=
 
 recover = Form('recover', action='/account/recover', method='post', children=[
         EmailField('email', autocapitalize="off", autocorrect="off", spellcheck="false", class_="span12", placeholder=L_("E-Mail Address")),
+        BlankSubmit('submit'),
         HiddenField('redirect'),
     ])
 
@@ -46,5 +47,6 @@ reset_password = Form('recover', action='/account/recover', method='post', child
         PasswordField('pass2', class_="span12 poor", placeholder=L_("Verify Password"),maxlength="100"),
         HiddenField('recovery_key'),
         HiddenField('email'),
+        BlankSubmit('submit'),
         HiddenField('redirect'),
     ])

--- a/brave/core/account/form.py
+++ b/brave/core/account/form.py
@@ -33,6 +33,7 @@ register = Form('register', action='/account/register', method='post', children=
         EmailField('email', autocapitalize="off", autocorrect="off", spellcheck="false", class_="span12", placeholder=L_("E-Mail Address"), required="true", datavalidate="/account/exists", datavalidatekey="email", datavalidatecheck="available"),
         PasswordField('password', class_="span12 poor", placeholder=L_("Password"), maxlength="100", required="true", pattern="\S+", datavalidate="/account/entropy", datavalidatekey="password", datavalidatecheck="approved"),
         PasswordField('pass2', class_="span12 poor", placeholder=L_("Verify Password"), maxlength="100"),
+        BlankSubmit('submit'),
     ])
 
 recover = Form('recover', action='/account/recover', method='post', children=[

--- a/brave/core/account/template/recover.html
+++ b/brave/core/account/template/recover.html
@@ -94,7 +94,7 @@
             }
 
             $('#submit').click(process_recover);
-            $('#authenticate-form').submit(process_recover);
+            $('#recover-form').submit(process_recover);
         });
     </script>
 


### PR DESCRIPTION
Password management is still a little busted though (in Firefox at
least--clicking submit does not trigger 1password, but hitting enter
does).

Addresses part of the cause for #126. A full audit and browser check would still be worthwhile.
