### PR TITLE
Add escaping in a bunch of places

### DIFF
--- a/brave/core/application/template/list_apps.html
+++ b/brave/core/application/template/list_apps.html
@@ -56,11 +56,11 @@
                     % for record in records:
                     <tr data-id="${record.id}">
                         <td class="name">
-                            <a href="/application/${record.id}"><strong>${record.name}</strong></a><br>
-                            <span class="subtext">${record.description}</span>
+                            <a href="/application/${record.id}"><strong>${record.name | h}</strong></a><br>
+                            <span class="subtext">${record.description | h}</span>
                         </td>
                         <td class="actions">
-                            <a href=${record.site}><button class="btn btn-small authorize">Authorize</button></a>
+                            <a href=${record.site | u}><button class="btn btn-small authorize">Authorize</button></a>
                         </td>
                     </tr>
                     % endfor
@@ -91,11 +91,11 @@
                     % for record in devRecords:
                     <tr data-id="${record.id}">
                         <td class="name">
-                            <a href="/application/${record.id}"><strong>${record.name}</strong></a><br>
-                            <span class="subtext">${record.description}</span>
+                            <a href="/application/${record.id}"><strong>${record.name | h}</strong></a><br>
+                            <span class="subtext">${record.description | h}</span>
                         </td>
                         <td class="actions">
-                            <a href=${record.site}><button class="btn btn-small authorize">Authorize</button></a>
+                            <a href=${record.site | u}><button class="btn btn-small authorize">Authorize</button></a>
                         </td>
                     </tr>
                     % endfor

--- a/brave/core/application/template/list_grants.html
+++ b/brave/core/application/template/list_grants.html
@@ -84,11 +84,11 @@
                     % for record in records:
                     <tr data-id="${record.id}">
                         <td class="name">
-                            <a href="${record.application.site}"><strong>${record.application.name}</strong></a> <i class="fa fa-external-link muted"></i><br>
-                            <span class="subtext">${record.application.description}</span>
+                            <a href="${record.application.site | u}"><strong>${record.application.name | h}</strong></a> <i class="fa fa-external-link muted"></i><br>
+                            <span class="subtext">${record.application.description | h}</span>
                         </td>
                         <td class="character hidden-tablet hidden-phone">
-                            <img src="//image.eveonline.com/Character/${record.character.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${record.character.name}"> ${record.character.name}
+                            <img src="//image.eveonline.com/Character/${record.character.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${record.character.name | u}"> ${record.character.name}
                         </td>
                         <td class="date">
                             <time class="relative" datetime="${record.id.generation_time |n,f.iso}">${record.id.generation_time |n,f.pretty}</time>

--- a/brave/core/application/template/manage_apps.html
+++ b/brave/core/application/template/manage_apps.html
@@ -84,8 +84,8 @@
                     % for record in records:
                     <tr data-id="${record.id}">
                         <td class="name">
-                            <a href="/application/manage/${record.id}"><strong>${record.name}</strong></a><br>
-                            <span class="subtext">${record.description}</span>
+                            <a href="/application/manage/${record.id}"><strong>${record.name | h}</strong></a><br>
+                            <span class="subtext">${record.description | h}</span>
                         </td>
                         <td class="tr">
                             ${record.grants.count()}
@@ -127,14 +127,14 @@
                     % for record in adminRecords:
                     <tr data-id="${record.id}">
                         <td class="name">
-                            <a href="/application/manage/${record.id}"><strong>${record.name}</strong></a><br>
-                            <span class="subtext">${record.description}</span>
+                            <a href="/application/manage/${record.id}"><strong>${record.name | h}</strong></a><br>
+                            <span class="subtext">${record.description | h}</span>
                         </td>
                         <td class="owner">
-                            ${record.owner}
+                            ${record.owner | h}
                         </td>
                         <td class="url">
-                            <a href="${record.site}">${record.site}</a>
+                            <a href="${record.site | u}">${record.site | h}</a>
                         </td>
                         <td class="tr">
                             ${record.grants.count()}

--- a/brave/core/application/template/view_app.html
+++ b/brave/core/application/template/view_app.html
@@ -2,7 +2,7 @@
 
 <%inherit file="brave.core.template.master"/>
 
-<%block name="title">${app} — Application Details</%block>
+<%block name="title">${app | h} — Application Details</%block>
 
 <%block name="header">
     ${parent.header()}

--- a/brave/core/character/template/list.html
+++ b/brave/core/character/template/list.html
@@ -128,20 +128,20 @@
                         <td class="name">
                             <span class="ellipsis">
                             <img src="//image.eveonline.com/Character/${record.identifier}_32.jpg" style="vertical-align: -55%; margin-right: 5px; border-radius: 6px; width: 32px; height: 32px;">
-                            <strong>${record.name}</strong>
+                            <strong>${record.name | h}</strong>
                             </span>
                         </td>
                         <td class="corporation">
                             <span class="ellipsis">
                             <img src="//image.eveonline.com/Corporation/${record.corporation.identifier}_32.png" style="vertical-align: -55%; margin-right: 5px; width: 32px; height: 32px;">
-                            ${record.corporation.name}
+                            ${record.corporation.name | h}
                             </span>
                         </td>
                         <td class="alliance">
                             % if record.alliance:
                             <span class="ellipsis">
                             <img src="//image.eveonline.com/Alliance/${record.alliance.identifier}_32.png" style="vertical-align: -55%; margin-right: 5px; width: 32px; height: 32px;">
-                            ${record.alliance.name}
+                            ${record.alliance.name | h}
                             </span>
                             % else:
                             <em>None</em>
@@ -150,7 +150,7 @@
                         % if admin:
                         <td class="username">
                             <span class="ellipsis">
-                            ${record.owner}
+                            ${record.owner | h}
                             </span>
                         </td>
                         % else:

--- a/brave/core/group/template/group.html
+++ b/brave/core/group/template/group.html
@@ -2,7 +2,7 @@
 
 <%inherit file="brave.core.template.master"/>
 
-<%block name="title">${group.id} - ${group.title}</%block>
+<%block name="title">${group.id | h} - ${group.title | h}</%block>
 
 <%block name="post">
     ${parent.post()}
@@ -29,7 +29,7 @@
 <div class="container-fluid">
     <div id="pad-wrapper">
         <div class="row-fluid header">
-            <h3>${group.id} - ${group.title}</h3>
+            <h3>${group.id | h} - ${group.title | h}</h3>
         </div>
         <div class="row-fluid table">
             % if not len(group.rules):
@@ -38,16 +38,16 @@
                 Rules:
                 <ul>
                     % for rule in group.rules:
-                        <li>${rule.human_readable_repr()}</li>
+                        <li>${rule.human_readable_repr() | h}</li>
                     % endfor
                 </ul>
             % endif
         </div>
-        <form method="POST" action="/group/${group.id}/add_character">
+        <form method="POST" action="/group/${group.id | u}/add_character">
             <input name="name" type="text" />
             <input type="submit" class="btn btn-default" value="Add character" />
         </form>
-        <form method="POST" action="/group/${group.id}/remove_character">
+        <form method="POST" action="/group/${group.id | u}/remove_character">
             <input name="name" type="text" />
             <input type="submit" class="btn btn-default" value="Remove character" />
         </form>

--- a/brave/core/group/template/list_groups.html
+++ b/brave/core/group/template/list_groups.html
@@ -109,9 +109,9 @@
                     </thead>
                     <tbody>
                         % for group in groups:
-                            <tr data-id="${group.id}">
-                                <td><a href="/group/${group.id}">${group.id}</a></td>
-                                <td>${group.title}</td>
+                            <tr data-id="${group.id | u}">
+                                <td><a href="/group/${group.id | u}">${group.id | h}</a></td>
+                                <td>${group.title | h}</td>
                                 <td><button class="btn btn-danger btn-small delete"><i class="fa fa-times"></i></button></td>
                             </tr>
                         % endfor

--- a/brave/core/key/template/list.html
+++ b/brave/core/key/template/list.html
@@ -147,8 +147,8 @@
 
 <%def name="row(record)">
     <tr data-id="${record.id}">
-        <td class="key-id"><i class="fa fa-fw fa-${'check' if record.verified else 'times'}"></i> ${record.key}</td>
-        <td class="key-code"><span class="ellipsis">${record.code}</span></td>
+        <td class="key-id"><i class="fa fa-fw fa-${'check' if record.verified else 'times'}"></i> ${record.key | h}</td>
+        <td class="key-code"><span class="ellipsis">${record.code | h}</span></td>
         % if record.violation == "Character":
         <td class="security-violation"><font color="red">Character Security Violation.</font></td>
         % else:
@@ -156,7 +156,7 @@
         % endif
         <td class="characters hidden-tablet hidden-phone">
             % for char in record.characters:
-            <img src="http://image.eveonline.com/Character/${char.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${char.name}">
+            <img src="http://image.eveonline.com/Character/${char.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${char.name | u}">
             % endfor
         </td>
         <td class="key-date hidden-phone"><time datetime="${record.id.generation_time.isoformat().replace('+00:00', 'Z')}">${record.id.generation_time.isoformat(' ').replace('+00:00', '')}</time></td>
@@ -209,16 +209,16 @@
                 <tbody>
                     % for record in records:
                     <tr data-id="${record.id}">
-                        <td class="key-id"><i class="fa fa-fw fa-${'check' if record.verified else 'times'}"></i> ${record.key}</td>
+                        <td class="key-id"><i class="fa fa-fw fa-${'check' if record.verified else 'times'}"></i> ${record.key | h}</td>
                         % if record.violation == "Character":
                         <td class="security-violation" title="One or more characters associated with this key was found on another account. Join the 'Brave IT Team' channel in game for assistance."><font color="red">Character Security Violation.</font></td>
                         % else:
                         <td class="security-violation" title="All clear!"><font color="green">The BIA is always watching...</font></td>
                         % endif
-                        <td class="key-code"><span class="ellipsis">${record.code}</span></td>
+                        <td class="key-code"><span class="ellipsis">${record.code | h}</span></td>
                         <td class="characters hidden-tablet hidden-phone">
                             % for char in record.characters:
-                            <img src="//image.eveonline.com/Character/${char.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${char.name}">
+                            <img src="//image.eveonline.com/Character/${char.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${char.name | u}">
                             % endfor
                         </td>
                         <td class="key-date hidden-phone"><time datetime="${record.id.generation_time.isoformat().replace('+00:00', 'Z')}">${record.id.generation_time.isoformat(' ').replace('+00:00', '')}</time></td>

--- a/brave/core/template/authorize.html
+++ b/brave/core/template/authorize.html
@@ -2,7 +2,7 @@
 
 <%inherit file="brave.core.template.light"/>
 
-<%block name="title">${_("Authorize {0}").format(ar.application.name)}</%block>
+<%block name="title">${_("Authorize {0}").format(ar.application.name) | h}</%block>
 
 <%block name="header">
     ${parent.header()}
@@ -99,7 +99,7 @@
         <div class="auth">
             <h6>${_("Granting Authorization")}</h6>
             
-            <blockquote data-application="${ar.application.name}"></blockquote>
+            <blockquote data-application="${ar.application.name | u}"></blockquote>
             
             <p>This application wishes to know certain information about your character.  All applications are given access to the following information:</p>
             
@@ -124,7 +124,7 @@
                         % for record in characters:
                         <li><a tabindex="-1" href="#" data-id="${record.id}" class="allow"><span class="ellipsis">
                             <img src="//image.eveonline.com/Character/${record.identifier}_32.jpg" style="vertical-align: -60%; margin-right: 5px; border-radius: 6px; width: 32px; height: 32px;">
-                            <strong>${record.name}</strong>
+                            <strong>${record.name | h}</strong>
                             % if default == record:
                             <span class="label label-inverse" style="margin-left: 5px;">Default</span>
                             % endif

--- a/brave/core/template/dashboard.html
+++ b/brave/core/template/dashboard.html
@@ -33,14 +33,14 @@
         <div class="header">
             <img src="//image.eveonline.com/Character/${web.user.primary.identifier}_128.jpg" class="avatar">
             
-            <h3 class="name">${web.user.primary.name}</h3>
+            <h3 class="name">${web.user.primary.name | h}</h3>
             <span class="area">
-            ${", ".join(web.user.primary.titles)}
+            ${", ".join(web.user.primary.titles) | h}
             </span>
             <div class="area">
-                <a target="_blank" href="https://gate.eveonline.com/Corporation/${web.user.primary.corporation.name}">${web.user.primary.corporation.name}</a>
+                <a target="_blank" href="https://gate.eveonline.com/Corporation/${web.user.primary.corporation.name | u}">${web.user.primary.corporation.name | h}</a>
                 % if web.user.primary.alliance:
-                <span>›</span> <a target="_blank" href="https://gate.eveonline.com/Alliance/${web.user.primary.alliance.name}">${web.user.primary.alliance.name}</a>
+                <span>›</span> <a target="_blank" href="https://gate.eveonline.com/Alliance/${web.user.primary.alliance.name | u}">${web.user.primary.alliance.name | h}</a>
                 % endif
             </div>
         </div>
@@ -83,7 +83,7 @@
                             % for attempt in web.user.attempts.order_by('-id').limit(10):
                             <tr>
                                 <td><time datetime="${attempt.id.generation_time.isoformat().replace('+00:00', 'Z')}">${attempt.id.generation_time.isoformat(' ').replace('+00:00', '')}</time></td>
-                                <td>${attempt.location}</td>
+                                <td>${attempt.location | h}</td>
                                 % if attempt.success:
                                 <td><i class="fa fa-check-circle-o fa-lg text-success"></i></td>
                                 % else:
@@ -107,7 +107,7 @@
                 <h4>Authorized Applications</h4>
                 <ul>
                     % for grant in web.user.grants:
-                    <li><a target="_blank" href="${grant.application.site}" title="${grant.application.description}">${grant.application.name}</a></li>
+                    <li><a target="_blank" href="${grant.application.site | u}" title="${grant.application.description | u}">${grant.application.name | h}</a></li>
                     % endfor
                 </ul>
                 
@@ -116,7 +116,7 @@
                 <h4>Group Membership</h4>
                 <ul>
                     % for id, group in web.user.primary.tags.iteritems():
-                    <li>${group.title}</li>
+                    <li>${group.title | h}</li>
                     % endfor
                 </ul>
             </div>

--- a/brave/core/template/navigation.html
+++ b/brave/core/template/navigation.html
@@ -23,7 +23,7 @@ areas = [
 % if web.auth.authenticated:
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                    <i class="fa fa-user"></i><span class="hidden-phone"> ${web.user.username}</span>
+                    <i class="fa fa-user"></i><span class="hidden-phone"> ${web.user.username | h}</span>
                     <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">


### PR DESCRIPTION
This does not solve everything, but it's a big step. Improving on this
will probably require fixing the confirm dialog.

Longer term steps:
- Don't substitute values into JS. Move JS out of templates to help
  this not happen accidentally.
- Move to a templating language that automatically does context-aware
  escaping. Because it's not the 1990s.
