### PR TITLE
Move the keymask classes to brave.core.util.eve.

### DIFF
--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -14,7 +14,7 @@ from marrow.util.convert import boolean
 from brave.core.application.model import Application
 from brave.core.api.model import AuthenticationBlacklist, AuthenticationRequest
 from brave.core.api.util import SignedController
-from brave.core.key.model import EVECharacterKeyMask
+from brave.core.util.eve import EVECharacterKeyMask
 
 
 log = __import__('logging').getLogger(__name__)

--- a/brave/core/application/model.py
+++ b/brave/core/application/model.py
@@ -97,6 +97,8 @@ class ApplicationGrant(Document):
     @property
     def mask(self):
         """Returns a Key Mask object instead of just the integer."""
+        from brave.core.util.eve import EVECharacterKeyMask
+        
         if self._mask:
             return EVECharacterKeyMask(self._mask)
         return None

--- a/brave/core/key/controller.py
+++ b/brave/core/key/controller.py
@@ -12,8 +12,9 @@ from marrow.util.bunch import Bunch
 from mongoengine import ValidationError
 from mongoengine.errors import NotUniqueError
 
-from brave.core.key.model import EVECredential, EVECharacterKeyMask
+from brave.core.key.model import EVECredential
 from brave.core.util.predicate import authorize, authenticated, is_administrator
+from brave.core.util.eve import EVECharacterKeyMask
 
 
 log = __import__('logging').getLogger(__name__)

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -9,7 +9,7 @@ from marrow.util.bunch import Bunch
 
 from brave.core.util import strip_tags
 from brave.core.util.signal import update_modified_timestamp, trigger_api_validation
-from brave.core.util.eve import api
+from brave.core.util.eve import api, EVECharacterKeyMask, EVECorporationKeyMask
 
 
 log = __import__('logging').getLogger(__name__)
@@ -191,101 +191,3 @@ class EVECredential(Document):
         self.modified = datetime.utcnow()
         self.save()
         
-
-class EVEKeyMask:
-    """Base class for representing API key masks."""
-    
-    NULL = 0
-    
-    def __init__(self, mask):
-        self.mask = mask
-        
-    def __repr__(self):
-        return 'EVEKeyMask({0})'.format(self.mask)
-        
-    def has_access(self, mask):
-        if self.mask & mask:
-            return True
-            
-        return False
-        
-    def has_multiple_access(self, masks):
-        for apiCall in masks:
-            if not self.mask & apiCall:
-                return False
-        
-        return True
-        
-    def number_of_functions(self):
-        """Counts the number of ones in the binary representation of the mask."""
-        """This is equivalent to the number of functions that the key provides"""
-        """access to as long as the mask is a real mask."""
-        return bin(self.mask).count('1')
-
-class EVECharacterKeyMask(EVEKeyMask):
-    """Class for comparing character key masks against the required API calls."""
-    
-    ACCOUNT_BALANCE = 1
-    ASSET_LIST = 2
-    CALENDAR_EVENT_ATTENDEES = 4
-    CHARACTER_SHEET = 8
-    CONTACT_LIST = 16
-    CONTACT_NOTIFICATIONS = 32
-    FAC_WAR_STATS = 64
-    INDUSTRY_JOBS = 128
-    KILL_LOG = 256
-    MAIL_BODIES = 512
-    MAILING_LISTS = 1024
-    MAIL_MESSAGES = 2048
-    MARKET_ORDERS = 4096
-    MEDALS = 8192
-    NOTIFICATIONS = 16384
-    NOTIFICATION_TEXTS = 32768
-    RESEARCH = 65536
-    SKILL_IN_TRAINING = 131072
-    SKILL_QUEUE = 262144
-    STANDINGS = 524288
-    UPCOMING_CALENDAR_EVENTS = 1048576
-    WALLET_JOURNAL = 2097152
-    WALLET_TRANSACTIONS = 4194304
-    CHARACTER_INFO_PUBLIC = 8388608
-    CHARACTER_INFO_PRIVATE = 16777216
-    ACCOUNT_STATUS = 33554432
-    CONTRACTS = 67108864
-    LOCATIONS = 134217728
-    
-    def __repr__(self):
-        return 'EVECharacterKeyMask({0})'.format(self.mask)
-    
-class EVECorporationKeyMask(EVEKeyMask):
-    """Class for comparing corporation key masks against the required API calls."""
-    
-    ACCOUNT_BALANCE = 1
-    ASSET_LIST = 2
-    MEMBER_MEDALS = 4
-    CORPORATION_SHEET = 8
-    CONTACT_LIST = 16
-    CONTAINER_LOG = 32
-    FAC_WAR_STATS = 64
-    INDUSTRY_JOBS = 128
-    KILL_LOG = 256
-    MEMBER_SECURITY = 512
-    MEMBER_SECURITY_LOG = 1024
-    MEMBER_TRACKING_LIMITED = 2048
-    MARKET_ORDERS = 4096
-    MEDALS = 8192
-    OUTPOST_LIST = 16384
-    OUTPOST_SERVICE_DETAIL = 32768
-    SHAREHOLDERS = 65536
-    STARBASE_DETAIL = 131072
-    STANDINGS = 262144
-    STARBASE_LIST = 524288
-    WALLET_JOURNAL = 1048576
-    WALLET_TRANSACTIONS = 2097152
-    TITLES = 4194304
-    CONTRACTS = 8388608
-    LOCATIONS = 16777216
-    MEMBER_TRACKING_EXTENDED = 33554432
-    
-    def __repr__(self):
-        return 'EVECorporationKeyMask({0})'.format(self.mask)

--- a/brave/core/util/eve.py
+++ b/brave/core/util/eve.py
@@ -175,7 +175,6 @@ class APICall(Document):
     @property
     def mask(self):
         """Returns a Key Mask object instead of just the integer."""
-        from brave.core.key.model import EVECharacterKeyMask
         
         #Every call seems to be Meta anyways...
         if self.kind == "Meta" or self.kind =="m":
@@ -356,3 +355,105 @@ def populate_calls(force=False):
             row.description,
             row.accessMask,
             row.groupID).save()
+            
+            
+    """Classes for storing, interpreting, and comparing key masks."""
+            
+class EVEKeyMask:
+    """Base class for representing API key masks."""
+    
+    NULL = 0
+    
+    def __init__(self, mask):
+        self.mask = mask
+        
+    def __repr__(self):
+        return 'EVEKeyMask({0})'.format(self.mask)
+        
+    def has_access(self, mask):
+        if self.mask & mask:
+            return True
+            
+        return False
+        
+    def has_multiple_access(self, masks):
+        for apiCall in masks:
+            if not self.mask & apiCall:
+                return False
+        
+        return True
+        
+    def number_of_functions(self):
+        """Counts the number of ones in the binary representation of the mask."""
+        """This is equivalent to the number of functions that the key provides"""
+        """access to as long as the mask is a real mask."""
+        return bin(self.mask).count('1')
+
+class EVECharacterKeyMask(EVEKeyMask):
+    """Class for comparing character key masks against the required API calls."""
+    
+    ACCOUNT_BALANCE = 1
+    ASSET_LIST = 2
+    CALENDAR_EVENT_ATTENDEES = 4
+    CHARACTER_SHEET = 8
+    CONTACT_LIST = 16
+    CONTACT_NOTIFICATIONS = 32
+    FAC_WAR_STATS = 64
+    INDUSTRY_JOBS = 128
+    KILL_LOG = 256
+    MAIL_BODIES = 512
+    MAILING_LISTS = 1024
+    MAIL_MESSAGES = 2048
+    MARKET_ORDERS = 4096
+    MEDALS = 8192
+    NOTIFICATIONS = 16384
+    NOTIFICATION_TEXTS = 32768
+    RESEARCH = 65536
+    SKILL_IN_TRAINING = 131072
+    SKILL_QUEUE = 262144
+    STANDINGS = 524288
+    UPCOMING_CALENDAR_EVENTS = 1048576
+    WALLET_JOURNAL = 2097152
+    WALLET_TRANSACTIONS = 4194304
+    CHARACTER_INFO_PUBLIC = 8388608
+    CHARACTER_INFO_PRIVATE = 16777216
+    ACCOUNT_STATUS = 33554432
+    CONTRACTS = 67108864
+    LOCATIONS = 134217728
+    
+    def __repr__(self):
+        return 'EVECharacterKeyMask({0})'.format(self.mask)
+    
+class EVECorporationKeyMask(EVEKeyMask):
+    """Class for comparing corporation key masks against the required API calls."""
+    
+    ACCOUNT_BALANCE = 1
+    ASSET_LIST = 2
+    MEMBER_MEDALS = 4
+    CORPORATION_SHEET = 8
+    CONTACT_LIST = 16
+    CONTAINER_LOG = 32
+    FAC_WAR_STATS = 64
+    INDUSTRY_JOBS = 128
+    KILL_LOG = 256
+    MEMBER_SECURITY = 512
+    MEMBER_SECURITY_LOG = 1024
+    MEMBER_TRACKING_LIMITED = 2048
+    MARKET_ORDERS = 4096
+    MEDALS = 8192
+    OUTPOST_LIST = 16384
+    OUTPOST_SERVICE_DETAIL = 32768
+    SHAREHOLDERS = 65536
+    STARBASE_DETAIL = 131072
+    STANDINGS = 262144
+    STARBASE_LIST = 524288
+    WALLET_JOURNAL = 1048576
+    WALLET_TRANSACTIONS = 2097152
+    TITLES = 4194304
+    CONTRACTS = 8388608
+    LOCATIONS = 16777216
+    MEMBER_TRACKING_EXTENDED = 33554432
+    
+    def __repr__(self):
+        return 'EVECorporationKeyMask({0})'.format(self.mask)
+


### PR DESCRIPTION
Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
