### PR TITLE
Remove the unnecessary functions in the EVEKeyMask classes, add a...

### DIFF
--- a/UPDATE-README
+++ b/UPDATE-README
@@ -2,6 +2,7 @@
 #updating their core installations to a new version.
 #WARNING: Backup your database regularly and before making any changes to it.
 
+***v0.5:***
 5ec0143: All usernames and email addresses in the database need to be lowercased.
     brave/core/scripts/case_migration.py should resolve this for you.
 ad709e0: It is highly recommended that admins remove all characters whose owners no longer have a valid API key for them.
@@ -9,3 +10,10 @@ ad709e0: It is highly recommended that admins remove all characters whose owners
 3016b8b: KeyID is made unique in the Credentials collection; all duplicate keys must be 
     purged from the database prior to upgrading. brave/core/scripts/fix_key_duplicates.py should resolve this for you.
     Removal of orphaned characters (see ad709e0) is now required.
+
+***v0.5.2+***
+6b3c4a5: Changes were made to the populate_calls function. Admins must run populate_calls(True) from paster shell after
+    updating to this version. 
+    Commands: 
+        from brave.core.util.eve import populate_calls
+        populate_calls(True)                    

--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -11,10 +11,9 @@ from marrow.util.url import URL
 from marrow.util.object import load_object as load
 from marrow.util.convert import boolean
 
-from brave.core.application.model import Application
 from brave.core.api.model import AuthenticationBlacklist, AuthenticationRequest
 from brave.core.api.util import SignedController
-from brave.core.util.eve import EVECharacterKeyMask
+from brave.core.util.eve import EVECharacterKeyMask, api
 
 
 log = __import__('logging').getLogger(__name__)
@@ -140,10 +139,10 @@ class CoreAPI(SignedController):
         character = token.character
         
         # Step 2: Update info about the character from the EVE API
-        mask, key = character.credential_multi_for((EVECharacterKeyMask.CHARACTER_SHEET,
-         EVECharacterKeyMask.CHARACTER_INFO_PUBLIC, EVECharacterKeyMask.NULL))
+        mask, key = character.credential_multi_for((api.char.CharacterSheet.mask,
+                                                    api.eve.CharacterInfo.mask, EVECharacterKeyMask.NULL))
         
-        #User has no keys registered.
+        # User has no keys registered.
         if not key:
             return None
             

--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -140,7 +140,7 @@ class CoreAPI(SignedController):
         
         # Step 2: Update info about the character from the EVE API
         mask, key = character.credential_multi_for((api.char.CharacterSheet.mask,
-                                                    api.eve.CharacterInfo.mask, EVECharacterKeyMask.NULL))
+                                                    api.char.CharacterInfoPublic.mask, EVECharacterKeyMask.NULL))
         
         # User has no keys registered.
         if not key:

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -103,7 +103,7 @@ class EVECredential(Document):
 
         if self.mask.has_access(api.char.CharacterSheet.mask):
             info = api.char.CharacterSheet(self, characterID=info.characterID)
-        elif self.mask.has_access(api.eve.CharacterInfo.mask):
+        elif self.mask.has_access(api.char.CharacterInfoPublic.mask):
             info = api.eve.CharacterInfo(self, characterID=info.characterID)
 
         char.corporation, char.alliance = self.get_membership(info)

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -104,7 +104,7 @@ class EVECredential(Document):
         if self.mask.has_access(api.char.CharacterSheet.mask):
             info = api.char.CharacterSheet(self, characterID=info.characterID)
         elif self.mask.has_access(api.char.CharacterInfoPublic.mask):
-            info = api.eve.CharacterInfo(self, characterID=info.characterID)
+            info = api.char.CharacterInfoPublic(self, characterID=info.characterID)
 
         char.corporation, char.alliance = self.get_membership(info)
 

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -101,9 +101,9 @@ class EVECredential(Document):
                 self.violation = "Character"
                 return
 
-        if self.mask.has_access(EVECharacterKeyMask.CHARACTER_SHEET):
+        if self.mask.has_access(api.char.CharacterSheet.mask):
             info = api.char.CharacterSheet(self, characterID=info.characterID)
-        elif self.mask.has_access(EVECharacterKeyMask.CHARACTER_INFO_PUBLIC):
+        elif self.mask.has_access(api.eve.CharacterInfo.mask):
             info = api.eve.CharacterInfo(self, characterID=info.characterID)
 
         char.corporation, char.alliance = self.get_membership(info)

--- a/brave/core/util/eve.py
+++ b/brave/core/util/eve.py
@@ -354,19 +354,19 @@ def populate_calls(force=False):
         APIGroup(row.groupID, row.name, row.description).save()
     
     for row in result.calls.row:
-        if row.type.lower()[:4] != 'char' or row.name != 'CharacterInfo':
-            APICall(row.type.lower()[:4] + '.' + row.name,
-                type_mapping[row.type],
-                row.description,
-                row.accessMask,
-                row.groupID).save()
-        else:
+        if row.type.lower()[:4] == 'char' and row.name == 'CharacterInfo':
             APICall(row.type.lower()[:4] + '.' + row.name + ('Public' if row.accessMask == 8388608 else 'Private'),
                 type_mapping[row.type],
                 row.description,
                 row.accessMask,
                 row.groupID,
                 'eve.CharacterInfo').save()
+        else:
+            APICall(row.type.lower()[:4] + '.' + row.name,
+                type_mapping[row.type],
+                row.description,
+                row.accessMask,
+                row.groupID).save()
             
             
     """Classes for storing, interpreting, and comparing key masks."""

--- a/brave/core/util/eve.py
+++ b/brave/core/util/eve.py
@@ -176,8 +176,7 @@ class APICall(Document):
     def mask(self):
         """Returns a Key Mask object instead of just the integer."""
         
-        #Every call seems to be Meta anyways...
-        if self.kind == "Meta" or self.kind =="m":
+        if self.kind == "Meta" or self.kind == "m":
             return EVECharacterKeyMask(self._mask)
         elif self.kind == "Character" or self.kind == "c":
             return EVECharacterKeyMask(self._mask)
@@ -371,6 +370,9 @@ class EVEKeyMask:
         return 'EVEKeyMask({0})'.format(self.mask)
         
     def has_access(self, mask):
+        if isinstance(mask, EVEKeyMask):
+            mask = mask.mask
+        
         if self.mask & mask:
             return True
             
@@ -378,7 +380,7 @@ class EVEKeyMask:
         
     def has_multiple_access(self, masks):
         for apiCall in masks:
-            if not self.mask & apiCall:
+            if not self.has_access(apiCall):
                 return False
         
         return True
@@ -388,72 +390,42 @@ class EVEKeyMask:
         """This is equivalent to the number of functions that the key provides"""
         """access to as long as the mask is a real mask."""
         return bin(self.mask).count('1')
+        
+    def functionsAllowed(self):
+        """Returns a list with the APICall object of all the functions permitted by this mask."""
+        
+        funcs = []
+        if not self.functions():
+            return funcs
+            
+        for function in self.functions():
+            if self.has_access(function.mask.mask):
+                funcs.append(function)
+        
+        return funcs
+    
+    @staticmethod
+    def functions():
+        return None
+        
 
 class EVECharacterKeyMask(EVEKeyMask):
     """Class for comparing character key masks against the required API calls."""
     
-    ACCOUNT_BALANCE = 1
-    ASSET_LIST = 2
-    CALENDAR_EVENT_ATTENDEES = 4
-    CHARACTER_SHEET = 8
-    CONTACT_LIST = 16
-    CONTACT_NOTIFICATIONS = 32
-    FAC_WAR_STATS = 64
-    INDUSTRY_JOBS = 128
-    KILL_LOG = 256
-    MAIL_BODIES = 512
-    MAILING_LISTS = 1024
-    MAIL_MESSAGES = 2048
-    MARKET_ORDERS = 4096
-    MEDALS = 8192
-    NOTIFICATIONS = 16384
-    NOTIFICATION_TEXTS = 32768
-    RESEARCH = 65536
-    SKILL_IN_TRAINING = 131072
-    SKILL_QUEUE = 262144
-    STANDINGS = 524288
-    UPCOMING_CALENDAR_EVENTS = 1048576
-    WALLET_JOURNAL = 2097152
-    WALLET_TRANSACTIONS = 4194304
-    CHARACTER_INFO_PUBLIC = 8388608
-    CHARACTER_INFO_PRIVATE = 16777216
-    ACCOUNT_STATUS = 33554432
-    CONTRACTS = 67108864
-    LOCATIONS = 134217728
-    
     def __repr__(self):
         return 'EVECharacterKeyMask({0})'.format(self.mask)
+        
+    @staticmethod
+    def functions():
+        return APICall.objects(kind='c').order_by('mask')
+    
     
 class EVECorporationKeyMask(EVEKeyMask):
     """Class for comparing corporation key masks against the required API calls."""
     
-    ACCOUNT_BALANCE = 1
-    ASSET_LIST = 2
-    MEMBER_MEDALS = 4
-    CORPORATION_SHEET = 8
-    CONTACT_LIST = 16
-    CONTAINER_LOG = 32
-    FAC_WAR_STATS = 64
-    INDUSTRY_JOBS = 128
-    KILL_LOG = 256
-    MEMBER_SECURITY = 512
-    MEMBER_SECURITY_LOG = 1024
-    MEMBER_TRACKING_LIMITED = 2048
-    MARKET_ORDERS = 4096
-    MEDALS = 8192
-    OUTPOST_LIST = 16384
-    OUTPOST_SERVICE_DETAIL = 32768
-    SHAREHOLDERS = 65536
-    STARBASE_DETAIL = 131072
-    STANDINGS = 262144
-    STARBASE_LIST = 524288
-    WALLET_JOURNAL = 1048576
-    WALLET_TRANSACTIONS = 2097152
-    TITLES = 4194304
-    CONTRACTS = 8388608
-    LOCATIONS = 16777216
-    MEMBER_TRACKING_EXTENDED = 33554432
-    
     def __repr__(self):
         return 'EVECorporationKeyMask({0})'.format(self.mask)
-
+        
+    @staticmethod
+    def functions():
+        return APICall.objects(kind='o').order_by('mask')


### PR DESCRIPTION
...function method to them, and update all references to them to now refer to APICall objects.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com

Part of #192.
