### PR TITLE
Fix wrong ID in character table link

### DIFF
--- a/brave/core/character/template/charTable.html
+++ b/brave/core/character/template/charTable.html
@@ -26,7 +26,7 @@
                 <td class="name">
                     <span class="ellipsis">
                     <img src="//image.eveonline.com/Character/${record.identifier}_32.jpg" style="vertical-align: -55%; margin-right: 5px; border-radius: 6px; width: 32px; height: 32px;">
-                    <a href="/character/${record.identifier}">
+                    <a href="/character/${record.id}">
                     <strong>${record.name | h}</strong>
                     </a>
                     </span>


### PR DESCRIPTION
mongo IDs and eve IDs are confusing
