### PR TITLE
Add support for multiple characters in application grants

### DIFF
--- a/UPDATE-README
+++ b/UPDATE-README
@@ -17,3 +17,5 @@ ad709e0: It is highly recommended that admins remove all characters whose owners
     Commands: 
         from brave.core.util.eve import populate_calls
         populate_calls(True)                    
+1b58513: Changes were made to the structure of external application permissions grants.
+    brave/core/scripts/multiple_characters_grant_migration.py should migrate old grants to the new format.

--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -138,13 +138,7 @@ class CoreAPI(SignedController):
         token = ApplicationGrant.objects.get(id=token, application=request.service)
 
         # Step 2: Update info about the characters from the EVE API
-        # Support old grants that only have a single character.
-        # Could be removed after performing a database migration.
-        try:
-            characters = token.characters
-        except AttributeError:
-            characters = [token.character]
-
+        characters = token.characters
         characters_info = []
         for character in characters:
             mask, key = character.credential_multi_for((api.char.CharacterSheet.mask,

--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -143,7 +143,7 @@ class CoreAPI(SignedController):
         tags = None
         character = None
         for char in characters:
-            mask, key = character.credential_multi_for((api.char.CharacterSheet.mask,
+            mask, key = char.credential_multi_for((api.char.CharacterSheet.mask,
                                                         api.char.CharacterInfoPublic.mask, EVECharacterKeyMask.NULL))
 
             # Character has no keys registered.
@@ -163,16 +163,16 @@ class CoreAPI(SignedController):
                 },
                 'primary': token.user.primary == char,
             }
-            if character.alliance:
+            if char.alliance:
                 character_info['alliance'] = {
-                    'id': character.alliance.identifier,
-                    'name': character.alliance.name,
+                    'id': char.alliance.identifier,
+                    'name': char.alliance.name,
                 }
 
             # Step 3: Match ACLs.
             char_tags = []
             for group in Group.objects(id__in=request.service.groups):
-                if group.evaluate(token.user, character):
+                if group.evaluate(token.user, char):
                     char_tags.append(group.id)
             character_info['tags'] = char_tags
             if character_info['primary']:
@@ -185,7 +185,7 @@ class CoreAPI(SignedController):
         if character is None:
             # There are multiple characters, and none of them are the primary character. Just picking one now.
             character = characters[0]
-            tags = character_info[0]['tags']
+            tags = characters_info[0]['tags']
 
         return dict(
                 character = dict(id=character.identifier, name=character.name),

--- a/brave/core/application/controller/grant.py
+++ b/brave/core/application/controller/grant.py
@@ -52,17 +52,13 @@ class GrantInterface(HTTPMethod):
         valid, invalid = edit_grant(grant).native(kwargs)
 
         new_characters = []
-        print grant.user.characters
         for key, value in valid.items():
             try:
                 character = EVECharacter.objects.get(identifier=int(key))
             except EVECharacter.DoesNotExist:
                 continue
             if character in grant.user.characters and value:
-                print 'adding', character
                 new_characters.append(character)
-            else:
-                print 'not adding', character, value
 
         if new_characters:
             grant.characters = new_characters

--- a/brave/core/application/controller/grant.py
+++ b/brave/core/application/controller/grant.py
@@ -57,8 +57,7 @@ class GrantInterface(HTTPMethod):
                 character = EVECharacter.objects.get(identifier=int(key))
             except EVECharacter.DoesNotExist:
                 continue
-            if character in grant.user.characters and value:
-                new_characters.append(character)
+            new_characters.append(character)
 
         if new_characters:
             grant.characters = new_characters

--- a/brave/core/application/form.py
+++ b/brave/core/application/form.py
@@ -32,3 +32,12 @@ def manage_form(action='/application/manage/'):
                     TextArea('groups', L_("Group Identifiers"), transform=TagsTransform(), placeholder="E.g.: fc diplo myapp myapp.special", rows=3, class_="input-block-level")
                 ])
         ])
+
+
+def edit_grant(grant):
+    boxes = []
+    for character in grant.user.characters:
+        boxes.append(CheckboxField(str(character.identifier), character.name, title=''))
+    return Form('grant', action='/application/{}'.format(grant.id), method='post',
+            class_='modal-body tab-content form-horizontal', children=[
+                Tab('characters', L_('Characters'), class_='active', children=boxes),])

--- a/brave/core/application/model.py
+++ b/brave/core/application/model.py
@@ -87,7 +87,7 @@ class ApplicationGrant(Document):
     application = ReferenceField(Application, db_field='a')
     
     character = ReferenceField('EVECharacter', db_field='c')
-    characters = ListField(ReferenceField('EVECharacter'), db_field='chars')
+    characters = ListField(ReferenceField('EVECharacter'), db_field='chars', required=True)
     _mask = IntField(db_field='m', default=0)
     
     immutable = BooleanField(db_field='i', default=False)  # Onboarding is excempt from removal by the user.

--- a/brave/core/application/model.py
+++ b/brave/core/application/model.py
@@ -111,3 +111,14 @@ class ApplicationGrant(Document):
     
     def __repr__(self):
         return 'Grant({0}, "{1}", "{2}", {3})'.format(self.id, self.user, self.application, self.mask).encode('ascii', 'backslashreplace')
+
+    def remove_character(self, character):
+        """Removes the given character from the list of characters this grant applies to.
+
+        If there are no other characters for this grant, the grant is removed.
+        """
+        if len(self.characters) == 1:
+            self.delete()
+        else:
+            self.characters.remove(character)
+            self.save()

--- a/brave/core/application/model.py
+++ b/brave/core/application/model.py
@@ -87,6 +87,7 @@ class ApplicationGrant(Document):
     application = ReferenceField(Application, db_field='a')
     
     character = ReferenceField('EVECharacter', db_field='c')
+    characters = ListField(ReferenceField('EVECharacter'), db_field='chars')
     _mask = IntField(db_field='m', default=0)
     
     immutable = BooleanField(db_field='i', default=False)  # Onboarding is excempt from removal by the user.

--- a/brave/core/application/template/list_grants.html
+++ b/brave/core/application/template/list_grants.html
@@ -79,7 +79,7 @@
                         <th class="span5 sortable name">Name</th>
                         <th class="span3 sortable character hidden-tablet hidden-phone"><span class="line"></span>Characters</th>
                         <th class="span3 sortable date"><span class="line"></span>Authorized</th>
-                        <th class="span1 actions"><span class="line"></span></th>
+                        <th class="span1 actions"><span class="line"></span>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -98,6 +98,7 @@
                             <time class="relative" datetime="${record.id.generation_time |n,f.iso}">${record.id.generation_time |n,f.pretty}</time>
                         </td>
                         <td class="actions">
+                            <a class="btn btn-small" href="/application/${record.id}/" rel="modal" title="Edit application permissions." rel="tooltip" data-placement="left" data-trigger="genericform"><i class="fa fa-pencil"></i></a>
                             <button class="btn btn-danger btn-small delete" title="Revoke application permissions." rel="tooltip" data-placement="left"><i class="fa fa-times"></i></button>
                         </td>
                     </tr>

--- a/brave/core/application/template/list_grants.html
+++ b/brave/core/application/template/list_grants.html
@@ -77,7 +77,7 @@
                 <thead>
                     <tr>
                         <th class="span5 sortable name">Name</th>
-                        <th class="span3 sortable character hidden-tablet hidden-phone"><span class="line"></span>Character</th>
+                        <th class="span3 sortable character hidden-tablet hidden-phone"><span class="line"></span>Characters</th>
                         <th class="span3 sortable date"><span class="line"></span>Authorized</th>
                         <th class="span1 actions"><span class="line"></span></th>
                     </tr>
@@ -90,7 +90,9 @@
                             <span class="subtext">${record.application.description | h}</span>
                         </td>
                         <td class="character hidden-tablet hidden-phone">
-                            <img src="//image.eveonline.com/Character/${record.character.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${record.character.name | h}"> ${record.character.name}
+                            % for character in record.characters:
+                            <img src="//image.eveonline.com/Character/${character.identifier}_32.jpg" style="vertical-align: middle; margin-right: 5px; border-radius: 3px; width: 24px; height: 24px;" title="${character.name | h}">
+                            % endfor
                         </td>
                         <td class="date">
                             <time class="relative" datetime="${record.id.generation_time |n,f.iso}">${record.id.generation_time |n,f.pretty}</time>

--- a/brave/core/character/model.py
+++ b/brave/core/character/model.py
@@ -218,14 +218,16 @@ class EVECharacter(EVEEntity):
         """Removes all references to this character that imply ownership of the character."""
         
         # If this character is the primary character for the account, wipe that field for the user.
-        if self == self.owner.primary:
-            self.owner.primary = None
-            self.owner.save()
-                    
-        # Delete any application grants associated with the character.
-        for grant in self.owner.grants:
-            if self == grant.character:
-                grant.delete()
-        
-        self.owner = None
+        if self.owner:
+            if self == self.owner.primary:
+                self.owner.primary = None
+                self.owner.save()
+
+            # Delete any application grants associated with the character.
+            for grant in self.owner.grants:
+                if self in grant.characters:
+                    grant.remove_character(self)
+
+            self.owner = None
+
         self.save()

--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -97,6 +97,9 @@ class AuthorizeHandler(HTTPMethod):
             return 'json:', dict(success=True, location=str(target))
         
         characters = []
+        # Require at least one character
+        if 'characters[]' not in kwargs:
+            return 'json:', dict(success=False, message="Select at least one character.")
         character_ids = kwargs['characters[]']
         # Handle only one character being authorized
         if not isinstance(character_ids, list):

--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -62,7 +62,7 @@ class AuthorizeHandler(HTTPMethod):
                      ar=ar))
             return 'brave.core.template.authorize', dict(success=True, ar=ar, characters=characters, default=default)
         
-        ngrant = ApplicationGrant(user=u, application=ar.application, mask=grant.mask, expires=datetime.utcnow() + timedelta(days=30), character=grant.character)
+        ngrant = ApplicationGrant(user=u, application=ar.application, mask=grant.mask, expires=datetime.utcnow() + timedelta(days=30), characters=grant.characters)
         ngrant.save()
         
         ar.user = u

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -199,17 +199,27 @@ class EVECredential(Document):
             return self
         
         allCharsOK = True
+        pulled_characters = set()
 
         for char in result.characters.row:
             if 'corporationName' not in char:
                 log.error("corporationName missing for key %d", self.key)
                 continue
             
-            if not self.pull_character(char):
+            character = self.pull_character(char)
+            if not character:
                 allCharsOK = False
+            else:
+                pulled_characters.add(character)
+
         
         if allCharsOK and self.violation == "Character":
             self.violation = None
+
+        outdated_characters = set(self.characters) - pulled_characters
+        # This key no longer has access to these characters (like a character transfer)
+        for character in outdated_characters:
+            character.detach()
 
         self.modified = datetime.utcnow()
         self.save()

--- a/brave/core/scripts/multiple_characters_grant_migration.py
+++ b/brave/core/scripts/multiple_characters_grant_migration.py
@@ -1,0 +1,16 @@
+from brave.core.application.model import ApplicationGrant
+
+def migrate_characters(dry_run=True):
+    """Migrate from single-character application grants to multi-character ones
+    """
+
+    count = 0
+    for grant in ApplicationGrant.objects(character__ne=None):
+        print '{g.application.name} - {g.character.name}'.format(g=grant)
+        count += 1
+        if not dry_run:
+            grant.characters = [grant.character]
+            grant.character = None
+            grant.save()
+
+    print 'Updated {} grants'.format(count)

--- a/brave/core/template/authorize.html
+++ b/brave/core/template/authorize.html
@@ -19,8 +19,25 @@
         p, ul { text-align: left; }
         li { line-height: 1.2em; }
         
-        .login-wrapper .box { width: 500px; }
-        .login-wrapper .box .content-wrap { width: 440px; }
+        .login-wrapper .box { width: 575px; }
+        .login-wrapper .box .content-wrap { width: 515px; }
+        .btn-group-vertical button { width: 100%; }
+        .btn-checkbox.active {
+            border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+            color: #ffffff;
+            background-color: #0044cc;
+            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+            background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
+            background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
+            background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
+            background-image: -o-linear-gradient(top, #0088cc, #0044cc);
+            background-image: linear-gradient(to bottom, #0088cc, #0044cc);
+            background-repeat: repeat-x;
+            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
+            filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+        }
+        figure { margin: 0px; }
+         .row { margin-left: initial;}
     </style>
 </%block>
 
@@ -30,16 +47,15 @@
     <script type="text/javascript" charset="utf-8">
         $(function(){
             function process(){
-                var self = $(this),
-                    id = self.data('id');
-                
                 // Fade to the progress spinner.
                 $('.auth').animate({opacity: 0.25}, 250);
                 $('.btn').addClass('disabled').attr('disabled', true);
                 $('.overlay.wait').fadeIn(250);
-                
+
                 // Submit XHR request.
-                var receipt = $.post(window.location, {grant: true, character: id});
+                var chars = $('button.active').map(function (i, val){ return $(val).data('id');}).get();
+                var data = {grant: true, 'characters': chars};
+                var receipt = $.post(window.location, data);
                 receipt.fail(function(jqXHR, textStatus, errorThrown){
                     // Something went wrong.
                     console.log(jqXHR, textStatus, errorThrown);
@@ -109,41 +125,42 @@
 
 <div class="box">
     <div class="content-wrap authentication clearfix">
-        <div class="auth">
-            <h6>${_("Granting Authorization")}</h6>
-            
-            <blockquote data-application="${ar.application.name | h}"></blockquote>
-            
-            <p>This application wishes to know certain information about your character.  All applications are given access to the following information:</p>
-            
-            <ul>
-                <li><strong>Public Character Information</strong><span class="pull-right">Name, Corporation, Alliance</span></li>
-            </ul>
-            
-            <!--
-            <p>Additionally, this application requires the following additional information:</p>
-            
-            <ul>
+        <div class="auth row">
+            <div class="span9">
+                <h6>${_("Granting Authorization")}</h6>
+
+                <blockquote data-application="${ar.application.name | h}"></blockquote>
+
+                <p>This application wishes to know certain information about your character.  All applications are given access to the following information:</p>
+
+                <ul>
+                    <li><strong>Public Character Information</strong><span class="pull-right">Name, Corporation, Alliance</span></li>
+                </ul>
+
+                <!--
+                <p>Additionally, this application requires the following additional information:</p>
+
+                <ul>
                 <li>permission</li>
                 <li>permission</li>
-            </ul>
-            -->
-            
-            <div style="text-align: right; margin-top: 30px;">
-                <div class="btn-group dropup">
-                    <a class="btn btn-success btn-large allow" style="padding-left: 50px;" href="#" data-id="${default.id}"><img src="//image.eveonline.com/Character/${default.identifier}_32.jpg" style="border-radius: 4px; position: absolute; left: 4px; top: 4px; border: 1px inset rgba(127,127,127,0.5);"> Authorize</a>
-                    <a class="btn btn-success btn-large dropdown-toggle" data-toggle="dropdown" href="#"><i class="fa fa-caret-up"></i></a>
-                    <ul class="dropdown-menu" style="width: 300px; left: auto; right: 0px;">
-                        % for record in characters:
-                        <li><a tabindex="-1" href="#" data-id="${record.id}" class="allow"><span class="ellipsis">
-                            <img src="//image.eveonline.com/Character/${record.identifier}_32.jpg" style="vertical-align: -60%; margin-right: 5px; border-radius: 6px; width: 32px; height: 32px;">
-                            <strong>${record.name | h}</strong>
-                            % if default == record:
-                            <span class="label label-inverse" style="margin-left: 5px;">Default</span>
-                            % endif
-                        </span></a></li>
-                        % endfor
-                    </ul>
+                </ul>
+                -->
+            </div>
+            <div class="span3">
+                <div class="btn-group btn-group-vertical" data-toggle="buttons-checkbox">
+                    % for record in characters:
+                    % if record == default:
+                    <button class="btn btn-checkbox active" data-id="${record.id}">
+                    % else:
+                    <button class="btn btn-checkbox" data-id="${record.id}">
+                    % endif
+                    <figure>
+                        <img src="//image.eveonline.com/Character/${record.identifier}_32.jpg">
+                        <figcaption><small>${record.name}</small><figcaption>
+                    </figure>
+                    </button>
+                    % endfor
+                    <button class="btn btn-success allow">Authorize</button>
                 </div>
                 <a class="btn btn-inverse pull-left" style="margin-top: 15px;">Deny Authorization</a>
             </div>
@@ -153,7 +170,6 @@
         <div class="overlay fa-4x result fail"><i class="fa fa-times fa-4x"></i></div>
         <div class="overlay fa-4x result success"><i class="fa fa-check fa-4x"></i></div>
         <div class="overlay fa-4x result bad"><i class="fa fa-exclamation-triangle fa-4x"></i></div>
-        
     </div>
 </div>
 

--- a/brave/core/template/authorize.html
+++ b/brave/core/template/authorize.html
@@ -50,6 +50,7 @@
                 // Fade to the progress spinner.
                 $('.auth').animate({opacity: 0.25}, 250);
                 $('.btn').addClass('disabled').attr('disabled', true);
+                $('#alerts').empty();
                 $('.overlay.wait').fadeIn(250);
 
                 // Submit XHR request.
@@ -76,6 +77,7 @@
                                 $('.overlay.fail').fadeOut(250);
                                 $('.auth').animate({opacity: 1}, 250);
                                 $('.btn').removeClass('disabled').attr('disabled', false);
+                                $('#alerts').append("<div class='alert alert-error'>" + data.message +"</div>");
                             });
                         }
                     });
@@ -145,6 +147,8 @@
                 <li>permission</li>
                 </ul>
                 -->
+                <div id="alerts">
+                </div>
             </div>
             <div class="span3">
                 <div class="btn-group btn-group-vertical" data-toggle="buttons-checkbox">


### PR DESCRIPTION
I think this should address #131. Backwards compatibility with old consumers of the api.core.info endpoint is maintained by using (in order of preference) the primary character, or the first character alphabetically (well, really whatever the db returns as the first character, I left that undefined) for the info returned by the old API.

I tried to work on the styling of the authorization window, and I think it looks _alright_, but it could do with some more work.

~~An area I'm still looking to improve on is allowing users to edit existing grants. This means users don't have to revoke and then re-authorize an app just to add (or remove) characters.~~ Done as of paxswill@8a823ff2d8c2b398c8bc7b38e09519aac951f0c8.
