### PR TITLE
Prevent settings edits on other users' accounts

### DIFF
--- a/brave/core/account/controller.py
+++ b/brave/core/account/controller.py
@@ -229,7 +229,9 @@ class Settings(HTTPMethod):
         query = dict(active=True)
         query[b'username'] = data.id
 
-        user = User.objects(**query).first()
+        query_user = User.objects(**query).first()
+        if query_user.id != user.id:
+            raise HTTPForbidden
 
         if data.form == "changepassword":
             passwd_ok, error_msg = _check_password(data.passwd, data.passwd1)


### PR DESCRIPTION
It turns out this was actually okay because all of the edits require
password entry currently. But that was really nonobvious.

I made a pass through the other controllers checking auth stuff; there
are a lot of places where we 500 on not-logged-in users, but that's when
as a result of checking IDs. It would be nicer to present a better error
message, but I think we're okay for now.
