### PR TITLE
Csrf protection (fixes #92)

### DIFF
--- a/brave/core/admin/controller.py
+++ b/brave/core/admin/controller.py
@@ -18,20 +18,15 @@ from brave.core.account.model import User
 
 class SearchCharInterface(HTTPMethod):
     """Handles /admin/search/char"""
-    
-    def get(self):
+    def get(self, character=None, charMethod=None, alliance=None, corporation=None, group=None, submit=None):
         
         # Have to be an admin to access admin pages.            
         if not is_administrator:
             raise HTTPNotFound()
-        
-        return 'brave.core.admin.template.searchChar', dict(area='admin')
-    
-    def post(self, character=None, charMethod=None, alliance=None, corporation=None, group=None):
-        
-        # Have to be an admin to access admin pages.            
-        if not is_administrator:
-            raise HTTPNotFound()
+
+        if not submit:
+            return 'brave.core.admin.template.searchChar', dict(area='admin')
+
         
         # Seed the initial results.
         chars = EVECharacter.objects()
@@ -73,19 +68,14 @@ class SearchCharInterface(HTTPMethod):
 
 class SearchKeyInterface(HTTPMethod):
     """Handles /admin/search/key"""
-    def get(self):
+    def get(self, keyID=None, keyMask=None, violation=None, submit=None):
         
         # Have to be an admin to access admin pages.            
         if not is_administrator:
             raise HTTPNotFound()
-        
-        return 'brave.core.admin.template.searchKey', dict(area='admin')
-    
-    def post(self, keyID=None, keyMask=None, violation=None):
-        
-        # Have to be an admin to access admin pages.            
-        if not is_administrator:
-            raise HTTPNotFound()
+
+        if not submit:
+            return 'brave.core.admin.template.searchKey', dict(area='admin')
         
         # Seed the initial results.
         keys = EVECredential.objects()
@@ -109,19 +99,14 @@ class SearchKeyInterface(HTTPMethod):
         
 class SearchUserInterface(HTTPMethod):
     """Handles /admin/search/user"""
-    def get(self):
+    def get(self, username=None, userMethod=None, ip=None, duplicate=None, submit=None):
         
         # Have to be an admin to access admin pages.            
         if not is_administrator:
             raise HTTPNotFound()
-        
-        return 'brave.core.admin.template.searchUser', dict(area='admin')
-    
-    def post(self, username=None, userMethod=None, ip=None, duplicate=None):
-        
-        # Have to be an admin to access admin pages.            
-        if not is_administrator:
-            raise HTTPNotFound()
+
+        if not submit:
+            return 'brave.core.admin.template.searchUser', dict(area='admin')
             
         # Seed the initial results.
         users = User.objects()

--- a/brave/core/admin/template/searchChar.html
+++ b/brave/core/admin/template/searchChar.html
@@ -38,7 +38,7 @@
             <h3>Administrative Search</h3>
         </div>
         <div class="span12">
-            <form method="POST" action="/admin/search/char" id="search" class="form-inline">
+            <form method="GET" action="/admin/search/char" id="search" class="form-inline">
                 <div class="span2">
                     <input name="character" type="text" placeholder="Character Name" class="span2"/>
                 </div>
@@ -61,7 +61,7 @@
                 <br>
                 <br>
                 <div class="span5"></div>
-                <input type="submit" class="btn btn-default" value="Search" />
+                <input type="submit" name="submit" class="btn btn-default" value="Search" />
             </form>
         </div>
         

--- a/brave/core/admin/template/searchChar.html
+++ b/brave/core/admin/template/searchChar.html
@@ -4,34 +4,6 @@
 
 <%block name="title">Search Characters</%block>
 
-<%block name="post">
-    ${parent.post()}
-
-    <script type="text/javascript" charset="utf-8">
-        $(function() {
-            $('#new-search').click(function() {
-                var form = $(this).parents(".modal-content").find("form");
-                var id = form.find('input[name=id]').val();
-                var title = form.find('input[name=title]').val();
-                $.post('/admin/search/char', {
-                        character: character,
-                        charMethod: charMethod,
-                        alliance: alliance,
-                        corporation: corporation,
-                        group: group
-                    }, function(data) {
-                        if (data.success) {
-                            alert(data.results)
-                        } else {
-                            alert(data.message);
-                        }
-                    }
-                );
-            });
-        });
-    </script>
-</%block>
-
 <div class="container-fluid">
     <div id="pad-wrapper">
         <div class="row-fluid header">

--- a/brave/core/admin/template/searchKey.html
+++ b/brave/core/admin/template/searchKey.html
@@ -37,7 +37,7 @@
             <h4>Valid violation values as of this release are 'Character' and 'None'.</h4>
         </div>
         <div class="span12">
-            <form method="POST" action="/admin/search/key" id="search" class="form-inline">
+            <form method="GET" action="/admin/search/key" id="search" class="form-inline">
                 <div class="span2">
                     <input name="keyID" type="text" placeholder="Key ID" class="span2"/>
                 </div>
@@ -50,7 +50,7 @@
                 <br>
                 <br>
                 <div class="span3"></div>
-                <input type="submit" class="btn btn-default" value="Search" />
+                <input type="submit" name="submit" class="btn btn-default" value="Search" />
             </form>
         </div>
         

--- a/brave/core/admin/template/searchKey.html
+++ b/brave/core/admin/template/searchKey.html
@@ -4,32 +4,6 @@
 
 <%block name="title">Search Keys</%block>
 
-<%block name="post">
-    ${parent.post()}
-
-    <script type="text/javascript" charset="utf-8">
-        $(function() {
-            $('#new-search').click(function() {
-                var form = $(this).parents(".modal-content").find("form");
-                var id = form.find('input[name=id]').val();
-                var title = form.find('input[name=title]').val();
-                $.post('/admin/search/key', {
-                        keyID: keyID,
-                        keyMask: keyMask,
-                        violation: violation,
-                    }, function(data) {
-                        if (data.success) {
-                            alert(data.results)
-                        } else {
-                            alert(data.message);
-                        }
-                    }
-                );
-            });
-        });
-    </script>
-</%block>
-
 <div class="container-fluid">
     <div id="pad-wrapper">
         <div class="row-fluid header">

--- a/brave/core/admin/template/searchUser.html
+++ b/brave/core/admin/template/searchUser.html
@@ -37,7 +37,7 @@
             <h4>Duplicate accepts values of 'char' and 'ip'.</h4>
         </div>
         <div class="span12">
-            <form method="POST" action="/admin/search/user" id="search" class="form-inline">
+            <form method="GET" action="/admin/search/user" id="search" class="form-inline">
                 <div class="span2">
                     <input name="username" type="text" placeholder="Username" class="span2"/>
                 </div>
@@ -57,7 +57,7 @@
                 <br>
                 <br>
                 <div class="span4"></div>
-                <input type="submit" class="btn btn-default" value="Search" />
+                <input type="submit" name="submit" class="btn btn-default" value="Search" />
             </form>
         </div>
         

--- a/brave/core/admin/template/searchUser.html
+++ b/brave/core/admin/template/searchUser.html
@@ -4,32 +4,6 @@
 
 <%block name="title">Search Users</%block>
 
-<%block name="post">
-    ${parent.post()}
-
-    <script type="text/javascript" charset="utf-8">
-        $(function() {
-            $('#new-search').click(function() {
-                var form = $(this).parents(".modal-content").find("form");
-                var id = form.find('input[name=id]').val();
-                var title = form.find('input[name=title]').val();
-                $.post('/admin/search/user', {
-                        userMethod: userMethod,
-                        ip: ip,
-                        duplicate: duplicate
-                    }, function(data) {
-                        if (data.success) {
-                            alert(data.results)
-                        } else {
-                            alert(data.message);
-                        }
-                    }
-                );
-            });
-        });
-    </script>
-</%block>
-
 <div class="container-fluid">
     <div id="pad-wrapper">
         <div class="row-fluid header">

--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -139,7 +139,7 @@ class RootController(StartupMixIn, Controller):
 
     def check_csrf(self):
         # portions of the application explicitly opted out of CSRF protection.
-        if request.path_info_peek() in 'api':
+        if request.path_info_peek() == 'api':
             return
 
         if request.headers.get('X-CSRF'):

--- a/brave/core/template/light.html
+++ b/brave/core/template/light.html
@@ -46,6 +46,9 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
         <script src="/js/vendor/jquery-ui-1.10.2.custom.min.js"></script>
+        <script src="/js/vendor/jquery.timeago.js" charset="utf-8"></script>
+        <script src="/js/vendor/jquery.cookie.js" charset="utf-8"></script>
+        <script src="/js/script.js"></script>
         </%block>
     </body>
 </html>


### PR DESCRIPTION
This requires that all effectful requests be done via ajax, which I
think is already true. If we wish to support normal forms, that is
possible, but will require slightly more work.

The "light" base template is not quite as light as before. Oh well.
