### PR TITLE
Require POST on effectful methods in group editor

### DIFF
--- a/brave/core/group/template/list_groups.html
+++ b/brave/core/group/template/list_groups.html
@@ -13,7 +13,7 @@
                 var form = $(this).parents(".modal-content").find("form");
                 var id = form.find('input[name=id]').val();
                 var title = form.find('input[name=title]').val();
-                $.post('/group/create', {
+                $.post('/group/', {
                         id: id,
                         title: title,
                     }, function(data) {

--- a/brave/core/util/__init__.py
+++ b/brave/core/util/__init__.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 import re
 from HTMLParser import HTMLParser
+from functools import wraps
 from marrow.util.object import load_object
+from web.core import request
+from web.core.http import HTTPMethodNotAllowed
 
 
 def load(area):
@@ -30,3 +33,12 @@ def strip_tags(html):
     #s = MLStripper()
     #s.feed(html)
     #return s.get_data()
+
+def post_only(f):
+    """A decorator to require POST requests to an endpoint."""
+    @wraps(f)
+    def wrapper(*args, **kw):
+        if request.method != 'POST':
+            raise HTTPMethodNotAllowed
+        return f(*args, **kw)
+    return wrapper


### PR DESCRIPTION
Why I didn't do this originally, I'm not sure.

Also, TIL, if you use `__lookup__`, whatever you return will be treated
like a Controller, regardless of whether it actually is or not.
