### PR TITLE
Fix authorization under csrf protection

### DIFF
--- a/brave/core/public/js/script.js
+++ b/brave/core/public/js/script.js
@@ -114,7 +114,10 @@ $(function(){
     // Hook CSRF token support into jQuery AJAX.
     $(document).ajaxSend(function(event, xhr, settings) {
         // Exit early if this is a foreign XHR request.
-        if ( /^http(s)?:.*/.test(settings.url) )
+        var parser = document.createElement('a');
+        parser.href = settings.url;
+        if ( parser.protocol != window.location.protocol ||
+             parser.host != window.location.host )
             return;
         
         var token = $.cookie('csrf');


### PR DESCRIPTION
Since the authorization page was posting to window.location, the url was
absolute, and the external-xhr check was triggering.

I cannot believe this is how one parses a URL in javascript.
