### PR TITLE
Pin size of image in authorize button to 32px

### DIFF
--- a/brave/core/template/authorize.html
+++ b/brave/core/template/authorize.html
@@ -131,7 +131,7 @@
             
             <div style="text-align: right; margin-top: 30px;">
                 <div class="btn-group dropup">
-                    <a class="btn btn-success btn-large allow" style="padding-left: 50px;" href="#" data-id="${default.id}"><img src="//image.eveonline.com/Character/${default.identifier}_32.jpg" style="border-radius: 4px; position: absolute; left: 4px; top: 4px; border: 1px inset rgba(127,127,127,0.5);"> Authorize</a>
+                    <a class="btn btn-success btn-large allow" style="padding-left: 50px;" href="#" data-id="${default.id}"><img src="//image.eveonline.com/Character/${default.identifier}_32.jpg" style="border-radius: 4px; position: absolute; left: 4px; top: 4px; border: 1px inset rgba(127,127,127,0.5); height: 32px;"> Authorize</a>
                     <a class="btn btn-success btn-large dropdown-toggle" data-toggle="dropdown" href="#"><i class="fa fa-caret-up"></i></a>
                     <ul class="dropdown-menu" style="width: 300px; left: auto; right: 0px;">
                         % for record in characters:


### PR DESCRIPTION
This way when script.js retina-ifies it, it stays the proper size.
