### PR TITLE
Admin area tweaks (fixes #266)

### DIFF
--- a/brave/core/account/controller.py
+++ b/brave/core/account/controller.py
@@ -418,7 +418,7 @@ class AccountInterface(HTTPMethod):
             
     def get(self):
         return 'brave.core.account.template.accountdetails', dict(
-            area='admin',
+            area='admin' if user.admin else 'account',
             account=self.user,
         )
 

--- a/brave/core/character/controller.py
+++ b/brave/core/character/controller.py
@@ -43,7 +43,7 @@ class CharacterInterface(HTTPMethod):
         
         return 'brave.core.character.template.charDetails', dict(
             char=self.char,
-            area='admin'
+            area='admin' if user.admin else 'chars'
         )
 
 class CharacterList(HTTPMethod):

--- a/brave/core/key/controller.py
+++ b/brave/core/key/controller.py
@@ -39,7 +39,7 @@ class KeyIndex(HTTPMethod):
         
     def get(self):
         return 'brave.core.key.template.keyDetails', dict(
-            area='admin',
+            area='admin' if user.admin else 'keys',
             admin=True,
             record=self.key
         )

--- a/brave/core/template/navigation.html
+++ b/brave/core/template/navigation.html
@@ -1,5 +1,5 @@
 ## encoding: utf-8
-<%!
+<%
 
 areas = [
         # ID         Icon            Label             Destination
@@ -7,6 +7,9 @@ areas = [
         ('keys',     'key',          "API Keys",       "/key/"),
         ('apps',     'puzzle-piece', "Applications",   "/application/"),
         ('chars',    'user',         "Characters",     "/character/"),
+    ]
+if web.auth.authenticated and web.user.admin:
+    areas += [
         ('group',    'group',        "Groups",         "/group/"),
         ('admin',    'dashboard',    "Admin Panel",    "/admin/"),
     ]


### PR DESCRIPTION
- show key/char/account pages as in admin area only if the current user is an admin
- hide group & admin areas in sidebar from non-admins. Once group joining exists we'll want to bring the groups area back for everyone but it's probably nicer to hide it for now.
