### PR TITLE
Get rid of core.admin.search, and make the search page only show an...

### DIFF
--- a/brave/core/admin/controller.py
+++ b/brave/core/admin/controller.py
@@ -153,6 +153,6 @@ class AdminController(Controller):
 
     search = SearchController()
     
-    @user_has_permission('core.admin.search')
+    @user_has_permission('core.admin.search.*', accept_any_matching=True)
     def index(self):
         return 'brave.core.admin.template.search', dict(area='admin')

--- a/brave/core/admin/template/search.html
+++ b/brave/core/admin/template/search.html
@@ -10,9 +10,15 @@
             <h3>Administrative Search</h3>
         </div>
         <div class="span12">
+            % if web.user.has_permission('core.admin.search.char'):
             <a href="/admin/search/char"><button>Search Characters</button></a>
+            % endif
+            % if web.user.has_permission('core.admin.search.key'):
             <a href="/admin/search/key"><button>Search Keys</button></a>
+            % endif
+            % if web.user.has_permission('core.admin.search.user'):
             <a href="/admin/search/user"><button>Search Users</button></a>
+            % endif
         </div>
     </div>
 </div>

--- a/permissions.txt
+++ b/permissions.txt
@@ -1,5 +1,4 @@
 core.account.view.*:Ability to view all user's account details
-core.admin.search:Ability to view /admin/search (not required to conduct any searches)
 core.admin.search.user:Ability to search for users
 core.admin.search.char:Ability to search for characters
 core.admin.search.key:Ability to search for keys


### PR DESCRIPTION
...option to search based on the search types a user has permission for.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
