### PR TITLE
Add permissions calls to the Core API

### DIFF
--- a/brave/core/api/core.py
+++ b/brave/core/api/core.py
@@ -14,12 +14,60 @@ from marrow.util.convert import boolean
 from brave.core.api.model import AuthenticationBlacklist, AuthenticationRequest
 from brave.core.api.util import SignedController
 from brave.core.util.eve import EVECharacterKeyMask, api
+from brave.core.permission.model import create_permission
 
 
 log = __import__('logging').getLogger(__name__)
 
 
+class PermissionAPI(SignedController):
+    def register(self, permission, description):
+        """Allows applications to register new permissions that they use. This is intended so that applications can
+        have permissions they won't necessarily know about before intialization (run-time permissions), such as
+        the ability to write to a specific forum. Applications are restricted to registering applications within their
+        own scope (as enforced elsewhere in the permissions setup).
+        
+        permission: The permission id that the application wishes to register
+        description: The description for the permission being registered.
+        
+        returns:
+            status: Success of the call
+            code: Error code if the call fails
+            message: Verbose description of the issue, should not be used to identify issue.
+        """
+        
+        app = request.service
+        
+        if not permission.startswith(app.short + "."):
+            log.debug('{0} attempted to register {1} but was unable to due to having an incorrect short.'.format(
+                app.name,
+                permission))
+                
+            return dict(
+                status="error",
+                code="argument.permission.invalid",
+                message="The permission supplied does not start with the short allocated to your application."
+            )
+        
+        # create_permission returns False if there's an id conflict
+        if not create_permission(permission, description):
+            log.debug('{0} attempted to register {1} but was unable to due to {1} already existing.'.format(
+                app.name,
+                permission))
+                
+            return dict(
+                status="error",
+                code="argument.permission.conflict",
+                message="The permission supplied already exists."
+            )
+        
+        log.info('{0} successfully registered {1}.'.format(app.name, permission))
+        return dict(status="success")
+
+
 class CoreAPI(SignedController):
+    permission = PermissionAPI()
+    
     def authorize(self, success=None, failure=None):
         """Prepare a incoming session request.
         

--- a/brave/core/permission/model.py
+++ b/brave/core/permission/model.py
@@ -10,6 +10,23 @@ log = __import__('logging').getLogger(__name__)
 GRANT_WILDCARD = '*'
 
 
+def create_permission(permission, description=None):
+    """This function creates and returns a permission object of the correct class (Permission vs. WildcardPermission).
+    As such, it is useful for creating a permission where you do not know at compile-time whether it is a Permission
+    or WildcardPermission. In the event of id conflicts (the permission already exists), this function returns False."""
+    
+    if Permission.objects(id=permission):
+        log.debug("Permission with id {0} already exists.".format(permission))
+        return False
+    
+    if GRANT_WILDCARD in permission:
+        perm = WildcardPermission(permission, description)
+    else:
+        perm = Permission(permission, description)
+        
+    return perm.save()
+
+
 class Permission(Document):
     meta = dict(
         collection='Permissions',


### PR DESCRIPTION
Originally intended to have more than 1 call in this PR, but given that Aranth pointed out that giving permissions to individual characters is a bad idea, I cut that out. I left the separate class in though due to the likelihood that we will add more calls to it in the future.
