### PR TITLE
Add caching of permissions to the Character and User models. Resolves #319

### DIFF
--- a/brave/core/account/model.py
+++ b/brave/core/account/model.py
@@ -53,6 +53,11 @@ class User(Document):
     
     # Python Magic Methods
     
+    def __init__(self, *args, **kw):
+        super(User, self).__init__(*args, **kw)
+        
+        self._permissions = []
+    
     def __repr__(self):
         return 'User({0}, {1})'.format(self.id, self.username).encode('ascii', 'backslashreplace')
     
@@ -64,6 +69,16 @@ class User(Document):
         return self.id.generation_time
 
     # Related Data Lookups
+    
+    @property
+    def permissions(self):
+        """Returns a user's permissions. This value is cached for the lifetime of the object, so actions which modify
+        a user's permissions will not be reflected in this value until the object is reinitialized. I don't think that
+        will cause any problems, as the User object should be reinitialized every time something important happens
+        (such as a page load)."""
+        # This is a property because if we try to set it as an attribute in __init__ we get an infinite loop
+        if not self._permissions:
+            self._permissions = self.__permissions__
     
     @property
     def credentials(self):
@@ -146,7 +161,7 @@ class User(Document):
         super(User, self).delete()
     
     @property
-    def permissions(self):
+    def __permissions__(self):
         """Returns all permissions that any character this user owns has."""
         
         perms = set()

--- a/brave/core/application/controller/browse.py
+++ b/brave/core/application/controller/browse.py
@@ -52,17 +52,14 @@ class BrowseController(Controller):
         records = list()
         devRecords = list()
         
-        # Cache the user's permissions
-        user_perms = user.permissions
-        
         # Retrieve non-development applications that the user is able to authorize
         for r in Application.objects(development__in=[False, None]):
-            if Permission.set_grants_permission(user_perms, r.authorize_perm):
+            if user.has_permission(r.authorize_perm):
                 records.append(r)
         
         # Retrieve development applications that the user is able to authorize
         for r in Application.objects(development=True):
-            if Permission.set_grants_permission(user_perms, r.authorize_perm):
+            if user.has_permission(r.authorize_perm):
                 devRecords.append(r)
         
         return 'brave.core.application.template.list_apps', dict(

--- a/brave/core/application/controller/manage.py
+++ b/brave/core/application/controller/manage.py
@@ -136,10 +136,8 @@ class ApplicationList(HTTPMethod):
     def get(self):
         adminRecords = set()
         
-        user_perms = user.permissions
-        
         for app in Application.objects():
-            if app.owner.id != user.id and Permission.set_grants_permission(user_perms, app.edit_perm):
+            if app.owner.id != user.id and user.has_permission(app.edit_perm):
                 adminRecords.add(app)
         
         records = Application.objects(owner=user._current_obj())

--- a/brave/core/character/model.py
+++ b/brave/core/character/model.py
@@ -176,6 +176,12 @@ class EVECharacter(EVEEntity):
     VIEW_PERM = 'core.character.view.{character_id}'
     LIST_PERM = 'core.character.list.all'
     
+    def __init__(self, *args, **kw):
+        super(EVECharacter, self).__init__(*args, **kw)
+        
+        self._permissions = dict()
+        self._permissions['all'] = self.__permissions__()
+    
     # DEPRECATED
     @property
     def tags(self):
@@ -206,6 +212,17 @@ class EVECharacter(EVEEntity):
         return char_groups
     
     def permissions(self, app=None):
+        """Returns the character's chached permissions. See brave.core.account.model for more information about issues
+        that might arise due to the caching."""
+        if not app:
+            return self._permissions['all']
+            
+        if app not in self._permissions:
+            self._permissions[app] = self.__permissions__(app)
+        
+        return self._permissions[app]
+    
+    def __permissions__(self, app=None):
         """Return all permissions that the character has that start with core or app.
            An app of None returns all of the character's permissions."""
         


### PR DESCRIPTION
This ensures that the permissions of the affected objects are evaluated
only once per object initialization (with the exception of app specific
permissions checks for EVECharacters). Prior to this change, every time
a user or character's permissions were checked, such as with
has_permission, the user's permissions were re-evaluated, which led to
substantial slow down on pages with a large number of permissions
checks, such as the group management page, (from feature/groups), the
application browse page, and the application management page.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
