### PR TITLE
Minor code cleanup: ACLRule human_readable_repr as __unicode__ and smarter __repr__.

### DIFF
--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -46,6 +46,11 @@ class ACLList(ACLRule):
             ('o', "Corporation"),
             ('a', "Alliance")
         ])
+    KIND_CLS = OrderedDict([
+            ('c', EVECharacter),
+            ('o', EVECorporation),
+            ('a', EVEAlliance)
+        ])
     
     kind = StringField(db_field='k', choices=KINDS.items())
     ids = ListField(IntField(), db_field='i')
@@ -66,17 +71,8 @@ class ACLList(ACLRule):
         # this acl rule doesn't match or is not applicable
         return self.grant if self.inverse else None
 
-    @staticmethod
-    def target_class(kind):
-        if kind == 'c':
-            return EVECharacter
-        elif kind == 'o':
-            return EVECorporation
-        elif kind == 'a':
-            return EVEAlliance
-
     def target_objects(self):
-        return self.target_class(self.kind).objects(identifier__in=self.ids)
+        return self.KIND_CLS[self.kind].objects(identifier__in=self.ids)
     
     def __repr__(self):
         return "ACLList({0} {1} {2} {3!r})".format(

--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -74,7 +74,7 @@ class ACLList(ACLRule):
         
         # this acl rule doesn't match or is not applicable
         return self.grant if self.inverse else None
-
+    
     def target_objects(self):
         return self.KIND_CLS[self.kind].objects(identifier__in=self.ids)
     
@@ -93,7 +93,6 @@ class ACLList(ACLRule):
                 prep=' in' if self.kind != 'c' else '',
                 set=' or '.join([o.name for o in self.target_objects()]),
             )
-
 
 
 class ACLKey(ACLRule):

--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -34,7 +34,7 @@ class ACLRule(EmbeddedDocument):
                 'if not' if self.inverse else 'if',
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return repr(self)
 
 
@@ -86,7 +86,7 @@ class ACLList(ACLRule):
                 self.ids
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return "{grant} if character is{not_}{prep} {set}".format(
                 grant='grant' if self.grant else 'deny',
                 not_=' not' if self.inverse else '',
@@ -121,7 +121,7 @@ class ACLKey(ACLRule):
                 self.KINDS[self.kind]
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return '{grant} if user has{not_} submitted a {kind} key'.format(
                 grant='grant' if self.grant else 'deny',
                 not_=' not' if self.inverse else '',
@@ -148,7 +148,7 @@ class ACLTitle(ACLRule):
                 self.titles
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return "{grant} if user {has} the corporate title {set}".format(
                 grant='grant' if self.grant else 'deny',
                 has="doesn't have" if self.inverse else 'has',
@@ -175,7 +175,7 @@ class ACLRole(ACLRule):
                 self.roles
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return "{grant} if user {has} the corporate role {set}".format(
                 grant='grant' if self.grant else 'deny',
                 has="doesn't have" if self.inverse else 'has',
@@ -204,7 +204,7 @@ class ACLMask(ACLRule):
                 self.mask
             )
 
-    def human_readable_repr(self):
+    def __unicode__(self):
         return '{grant} if user has{not_} submitted a key supporting permissions {mask}'.format(
                 grant='grant' if self.grant else 'deny',
                 not_=' not' if self.inverse else '',

--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -14,6 +14,11 @@ log = __import__('logging').getLogger(__name__)
 
 
 class ACLRule(EmbeddedDocument):
+    """The basic data structure and abstract API for ACL rules.
+    
+    See: https://github.com/bravecollective/core/wiki/Groups
+    """
+    
     meta = dict(
             abstract = True,
             allow_inheritance = True,

--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -33,8 +33,10 @@ class ACLRule(EmbeddedDocument):
         raise NotImplementedError()
     
     def __repr__(self):
-        return "{0}({1} {2})".format(
-                self.__class__.__name__,
+        return "{0}({1} {2})".format(self.__class__.__name__, self)
+    
+    def __unicode__(self):
+        return '{0} {1}'.format(
                 'grant' if self.grant else 'deny',
                 'if not' if self.inverse else 'if',
             )
@@ -85,9 +87,9 @@ class ACLList(ACLRule):
             )
 
     def __unicode__(self):
-        return "{grant} if character is{not_}{prep} {set}".format(
+        return "{grant} if character {is}{prep} {set}".format(
                 grant='grant' if self.grant else 'deny',
-                not_=' not' if self.inverse else '',
+                not_='is not' if self.inverse else 'is',
                 prep=' in' if self.kind != 'c' else '',
                 set=' or '.join([o.name for o in self.target_objects()]),
             )
@@ -113,10 +115,10 @@ class ACLKey(ACLRule):
         return self.grant if self.inverse else None
     
     def __unicode__(self):
-        return '{grant} if user has{not_} submitted a {kind} key'.format(
+        return '{grant} if user {has} submitted a {kind} key'.format(
                 grant='grant' if self.grant else 'deny',
-                not_=' not' if self.inverse else '',
-                kind=self.KINDS[self.kind]
+                not_='has not' if self.inverse else 'has',
+                kind=self.KINDS[self.kind].lower()
         )
 
 
@@ -175,8 +177,8 @@ class ACLMask(ACLRule):
         return self.grant if self.inverse else None
     
     def __unicode__(self):
-        return '{grant} if user has{not_} submitted a key supporting permissions {mask}'.format(
+        return '{grant} if user {has} submitted a key supporting permissions {mask}'.format(
                 grant='grant' if self.grant else 'deny',
-                not_=' not' if self.inverse else '',
+                has='has not' if self.inverse else 'has',
                 mask=self.mask,
         )

--- a/brave/core/group/acl.py
+++ b/brave/core/group/acl.py
@@ -39,9 +39,6 @@ class ACLRule(EmbeddedDocument):
                 'if not' if self.inverse else 'if',
             )
 
-    def __unicode__(self):
-        return repr(self)
-
 
 class ACLList(ACLRule):
     """Grant or deny access based on the character's ID, corporation ID, or alliance ID."""
@@ -115,13 +112,6 @@ class ACLKey(ACLRule):
         
         return self.grant if self.inverse else None
     
-    def __repr__(self):
-        return "ACLKey({0} {1} {2})".format(
-                'grant' if self.grant else 'deny',
-                'if not' if self.inverse else 'if',
-                self.KINDS[self.kind]
-            )
-
     def __unicode__(self):
         return '{grant} if user has{not_} submitted a {kind} key'.format(
                 grant='grant' if self.grant else 'deny',
@@ -142,13 +132,6 @@ class ACLTitle(ACLRule):
         # this acl rule doesn't match or is not applicable
         return self.grant if self.inverse else None
     
-    def __repr__(self):
-        return "ACLTitle({0} {1} {2!r})".format(
-                'grant' if self.grant else 'deny',
-                'if not' if self.inverse else 'if',
-                self.titles
-            )
-
     def __unicode__(self):
         return "{grant} if user {has} the corporate title {set}".format(
                 grant='grant' if self.grant else 'deny',
@@ -169,13 +152,6 @@ class ACLRole(ACLRule):
         # this acl rule doesn't match or is not applicable
         return self.grant if self.inverse else None
     
-    def __repr__(self):
-        return "ACLRole({0} {1} {2!r})".format(
-                'grant' if self.grant else 'deny',
-                'if not' if self.inverse else 'if',
-                self.roles
-            )
-
     def __unicode__(self):
         return "{grant} if user {has} the corporate role {set}".format(
                 grant='grant' if self.grant else 'deny',
@@ -198,13 +174,6 @@ class ACLMask(ACLRule):
         
         return self.grant if self.inverse else None
     
-    def __repr__(self):
-        return "ACLMask({0} {1} {2})".format(
-                'grant' if self.grant else 'deny',
-                'if not' if self.inverse else 'if',
-                self.mask
-            )
-
     def __unicode__(self):
         return '{grant} if user has{not_} submitted a key supporting permissions {mask}'.format(
                 grant='grant' if self.grant else 'deny',

--- a/brave/core/group/controller.py
+++ b/brave/core/group/controller.py
@@ -72,7 +72,7 @@ class OneGroupController(Controller):
 
         if not really:
             log.debug("not really")
-            return "json:", "\n".join([r.human_readable_repr() for r in rule_objects])
+            return "json:", "\n".join([unicode(r) for r in rule_objects])
 
         log.debug("really!")
         self.group.rules = rule_objects

--- a/brave/core/group/controller.py
+++ b/brave/core/group/controller.py
@@ -54,7 +54,7 @@ class OneGroupController(Controller):
             inverse = r['inverse'] == "true"
             if r['type'] == "list":
                 listify(r, 'names')
-                cls = ACLList.target_class(r['kind'])
+                cls = ACLList.KIND_CLS[r['kind']]
                 ids = [cls.objects(name=name).first().identifier for name in r['names']]
                 rule_objects.append(ACLList(grant=grant, inverse=inverse, kind=r['kind'], ids=ids))
             elif r['type'] == "key":
@@ -124,5 +124,5 @@ class GroupController(Controller):
 
     @authorize(is_administrator)
     def check_rule_reference_exists(self, kind, name):
-        cls = ACLList.target_class(kind)
+        cls = ACLList.KIND_CLS[kind]
         return "json:", dict(exists=bool(cls.objects(name=name)))

--- a/brave/core/group/template/group.html
+++ b/brave/core/group/template/group.html
@@ -194,7 +194,7 @@ def selected(bool):
     % elif isinstance(rule, ACLMask):
         ${aclmask(rule)}
     % else:
-        ERROR THIS WON'T WORK: ${rule.human_readable_repr()}
+        ERROR THIS WON'T WORK: ${rule}
     % endif
 </%def>
 


### PR DESCRIPTION
Conversion to standard Python idiom of allowing the objects to be coerced to text.  Simplifies use in templates (`${foo}` calls `unicode()` anyway) and by having `__repr__` use the string representation of the object, saves a lot of (almost, but not quite) code duplication.

Also threw in a change to eliminate a silly `@staticmethod` if-tree.  (See the specific commit for additional notes on that change.)
