### PR TITLE
Remove sign in when authenticating already authorized apps.

### DIFF
--- a/UPDATE-README
+++ b/UPDATE-README
@@ -37,3 +37,5 @@ feature/configLoginHistory: The config value 'core.login_history_days' should be
     
 feature/requireKeys: The config value 'core.require_recommended_key' should be added to the config to indicate whether
     the recommended key settings are required to authorize any application.
+
+feature/SSO: The config value 'core.sso.domain' should be added to the config file.

--- a/brave/core/account/controller.py
+++ b/brave/core/account/controller.py
@@ -3,7 +3,7 @@
 from marrow.util.bunch import Bunch
 from marrow.mailer.validator import EmailValidator
 from web.auth import authenticate, deauthenticate, user
-from web.core import Controller, HTTPMethod, request, config
+from web.core import Controller, HTTPMethod, request, config, session
 from web.core.http import HTTPFound, HTTPSeeOther, HTTPForbidden, HTTPNotFound
 from web.core.locale import _
 from mongoengine import ValidationError, NotUniqueError
@@ -66,6 +66,10 @@ class Authenticate(HTTPMethod):
                 return 'json:', dict(success=False, message=_("Invalid user name or password."))
 
             return self.get(redirect)
+
+        if redirect.lower().startswith("/authorize"):
+            session['ar'] = redirect.split('/')[2]
+            session.save()
 
         if request.is_xhr:
             return 'json:', dict(success=True, location=redirect or '/')

--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -93,8 +93,14 @@ class AuthorizeHandler(HTTPMethod):
                      ar=ar))
                      
             return 'brave.core.template.authorize', dict(success=True, ar=ar, characters=chars, default=default)
-        
-        ngrant = ApplicationGrant(user=u, application=ar.application, mask=grant.mask, expires=datetime.utcnow() + timedelta(days=ar.application.expireGrantDays), character=grant.character)
+
+        # User had to log in for this authorization, so we extend the expiry.
+        if session.get('ar', None) == ar.id:
+            expiration = datetime.utcnow() + timedelta(days=ar.application.expireGrantDays)
+        else:
+            expiration = grant.expires
+
+        ngrant = ApplicationGrant(user=u, application=ar.application, mask=grant.mask, expires=expiration, character=grant.character)
         ngrant.save()
         
         ar.user = u

--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -163,6 +163,13 @@ class RootController(StartupMixIn, Controller):
     admin = util.load('admin')
 
     def __call__(self, req):
+
+        if session and ('host' not in session or session['host'] != request.remote_addr):
+            session.invalidate()
+
+        session['host'] = request.remote_addr
+        session.save()
+
         if req.method not in ('GET', 'HEAD'):
             self.check_csrf()
         if not request.cookies.get('csrf'):

--- a/development.ini
+++ b/development.ini
@@ -73,6 +73,9 @@ core.login_history_days = 30
 # Require that the user have a key that meets the recommended key mask and kind in order to use that character for applications
 core.require_recommended_key = True
 
+#Set to the root level domain of your apps, i.e. bravecollective.com
+core.sso.domain = localhost
+
 [loggers]
 keys = root, core, webcore
 


### PR DESCRIPTION
I'm submitting this to start a discussion on whether it'd be worthwhile and to raise any security concerns that it might cause. In particular, given that there have been reports of session issues with the forums, I want to make 100% certain that there would be no such issues with Core. Additionally, it might be worth making sessions expire when someone tries to use that session id from a different IP address, though this will cause shortened session times for those with dynamic IP addresses, or that switch the location of their computer often.
