### PR TITLE
Revoke application authorizations for characters without verified API keys.

### DIFF
--- a/brave/core/application/model.py
+++ b/brave/core/application/model.py
@@ -109,6 +109,16 @@ class ApplicationGrant(Document):
     def mask(self, value):
         """Sets the value of the Key Mask"""
         self._mask = value
+
+    @classmethod
+    def remove_grants_for_character(cls, character):
+        """Removes the character from all Application Grants, removing the ability for application to access
+        the character's data; and forcing the user to reauthorize that character to any applications they wish
+        to use it on. Expected use cases include when a character gets detached from a user, and when a character
+        no longer has a key with valid requirements to meet an already authorized application."""
+
+        for grant in cls.objects(character=character):
+            grant.delete()
     
     def __repr__(self):
         return 'Grant({0}, "{1}", "{2}", {3})'.format(self.id, self.user, self.application, self.mask).encode('ascii', 'backslashreplace')

--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -8,6 +8,7 @@ from mongoengine.errors import NotUniqueError
 from requests.exceptions import HTTPError
 
 from brave.core.account.model import User
+from brave.core.application.model import ApplicationGrant
 from brave.core.util import strip_tags
 from brave.core.util.signal import update_modified_timestamp, trigger_api_validation
 from brave.core.util.eve import api, EVECharacterKeyMask, EVECorporationKeyMask
@@ -261,4 +262,13 @@ class EVECredential(Document):
         
         self.modified = datetime.utcnow()
         self.save()
+
+        for c in self.characters:
+            char_has_verified_key = False
+            for k in c.credentials:
+                if k.verified:
+                    char_has_verified_key = True
+            if not char_has_verified_key:
+                ApplicationGrant.remove_grants_for_character(c)
+
         return self


### PR DESCRIPTION
Whenever an API key is updated, all characters on it are now checked
for verified API keys, and if they have none all applications
authorized for that character are deleted. A new function was added to
ApplicationGrant that removes all application authorizations for a user.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
