### PR TITLE
Fix a bug where groups were disclosed to unauthorized users.

### DIFF
--- a/brave/core/group/controller.py
+++ b/brave/core/group/controller.py
@@ -30,6 +30,9 @@ class OneGroupController(Controller):
             self.group = Group.objects.get(id=id)
         except Group.DoesNotExist:
             raise HTTPNotFound()
+
+        if not user.has_permission(self.group.view_perm):
+            raise HTTPNotFound()
     
     @post_only
     @user_has_permission(Group.EDIT_REQUESTS_PERM, group_id='self.group.id')


### PR DESCRIPTION
Users without the permission to view a group were given a 404 if the
group did not exist, but a 403 if it existed but they lacked
permission. This change includes a quick fix to return a 404 if the
user does not have the ability to view a group.

I'm considering adding a keyword argument to user_has_permission where the caller can indicate whether the function being accessed is secret and that a 404 should be returned rather than a 403. Any thoughts on that?
