### PR TITLE
Fix typo in error message when use has no characters with sufficient API.

### DIFF
--- a/brave/core/controller.py
+++ b/brave/core/controller.py
@@ -87,8 +87,11 @@ class AuthorizeHandler(HTTPMethod):
                 default = u.primary if u.primary in chars else chars[0]
             else:
                 return ('brave.core.template.authorize',
-                dict(success=False, message=_("You do not have any API keys on your account which match the requirements for this service. Please add an {1} API key with a mask of <a href='/key/mask/{0}'>{0}</a> or better, please add an API key with that mask to your account.".format(config['core.recommended_key_mask'], config['core.recommended_key_kind'])),
-                     ar=ar))
+                    dict(success=False, message=_
+                        ("You do not have any API keys on your account which match the requirements for this service. "
+                        "Please add an {1} API key with a mask of <a href='/key/mask/{0}'>{0}</a> or better to your account."
+                        .format(config['core.recommended_key_mask'], config['core.recommended_key_kind'])),
+                        ar=ar))
                      
             return 'brave.core.template.authorize', dict(success=True, ar=ar, characters=chars, default=default)
 


### PR DESCRIPTION
Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
