### PR TITLE
Tell users without an API key to add one on the overview. Resolves #363

### DIFF
--- a/brave/core/template/dashboard.html
+++ b/brave/core/template/dashboard.html
@@ -32,7 +32,11 @@
 <div class="container-fluid">
     <div id="pad-wrapper" class="user-profile">
     % if not web.user.primary:
-        Select your primary character by starring it on the <a href="/character">characters page</a>.
+        % if not web.user.credentials:
+            Add an API key to your account by going to the <a href="/key">key management page</a>.
+        % else:
+            Select your primary character by starring it on the <a href="/character">characters page</a>.
+        % endif
     % else:
         <div class="header">
             <img src="//image.eveonline.com/Character/${web.user.primary.identifier}_128.jpg" class="avatar">


### PR DESCRIPTION
Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
