### PR TITLE
Remove the wildcard evaluation from Group.permissions

### DIFF
--- a/brave/core/group/model.py
+++ b/brave/core/group/model.py
@@ -62,21 +62,11 @@ class Group(Document):
     
     @property
     def permissions(self):
-        """Returns the permissions that this group grants as Permission objects. Evaluates the wildcard permissions
-            as well."""
+        """Returns the permissions that this group grants as Permission objects. Note, this is mostly here for backwards
+        compatibility from when we evaluated Wildcard permissions out into all known Permissions (which we stopped doing
+        because it's horrifically slow."""
         
-        perms = set()
-        
-        for perm in self._permissions:
-            # if perm is not a wildcard permission, add it to the set.
-            if not isinstance(perm, WildcardPermission):
-                perms.add(perm)
-                continue
-                
-            for p in perm.get_permissions():
-                perms.add(p)
-                
-        return perms
+        return self._permissions
         
     def add_join_member(self, character):
         """Use this to prevent duplicates in the database when not checking if a user is already in the list, does not

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -73,6 +73,9 @@ class PermissionTest(unittest.TestCase):
         g._permissions.append(Permission.objects(id='*.test').first())
         g._permissions.append(Permission.objects(id='core.permission.grant').first())
         g.save()
-        self.assertEqual(g.permissions, set({Permission.objects(id='core.test').first(),
-            Permission.objects(id='mumble.test').first(), Permission.objects(id='core.permission.grant').first(),
-            Permission.objects(id='*.test').first()}))
+        self.assertTrue(Permission.set_grants_permission(g.permissions, 'core.test'))
+        self.assertTrue(Permission.set_grants_permission(g.permissions, 'mumble.test'))
+        self.assertTrue(Permission.set_grants_permission(g.permissions, 'core.permission.grant'))
+        self.assertTrue(Permission.set_grants_permission(g.permissions, '*.test'))
+        self.assertEqual(g.permissions, set(Permission.objects(id='core.permission.grant').first(),
+            Permission.objects(id='*.test').first()))


### PR DESCRIPTION
It's horribly slow, and the permission checking algorithms all
support omitting it. See aae40f8 for more details.

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
