### PR TITLE
Modify Group requests and join storage to use strings

### DIFF
--- a/UPDATE-README
+++ b/UPDATE-README
@@ -76,3 +76,7 @@ feature/configPassReqs: The config value 'core.required_pass_strength' should be
 
 feature/user-agent: The config value 'core.operator' should be added to the config, with a string representing
     the name of the alliance (or other group) operating this particular instance of Core.
+
+feature/speedUpGroupEval: Due to a Group model change, you'll need to run scripts/groups_requests_join_migration,
+    with dry run off before starting the service again. Backing up the database prior to the migration is strongly
+    encouraged.

--- a/brave/core/group/controller.py
+++ b/brave/core/group/controller.py
@@ -41,12 +41,12 @@ class OneGroupController(Controller):
         if not c:
             return 'json:', dict(success=False, message=_("Character with that name not found."))
             
-        if not c in self.group.requests:
+        if not c.name in self.group.requests:
             return 'json:', dict(success=False, message=_("Character with that name has no request to join this group."))
         
         log.info("Adding {0} to group {1} via REQUEST_ACCEPT approved by {2}".format(c.name, self.group.id, user.primary))
-        self.group.add_request_member(c)
-        self.group.requests.remove(c)
+        self.group.add_request_member(c.name)
+        self.group.requests.remove(c.name)
         self.group.save()
         
         return 'json:', dict(success=True)
@@ -58,11 +58,11 @@ class OneGroupController(Controller):
         if not c:
             return 'json:', dict(success=False, message=_("Character with that name not found."))
             
-        if not c in self.group.requests:
+        if not c.name in self.group.requests:
             return 'json:', dict(success=False, message=_("Character with that name has no request to join this group."))
         
         log.info("Rejecting {0}'s application to group {1} via REQUEST_DENY by {2}".format(c.name, self.group.id, user.primary))
-        self.group.requests.remove(c)
+        self.group.requests.remove(c.name)
         self.group.save()
         
         return 'json:', dict(success=True)
@@ -78,11 +78,11 @@ class OneGroupController(Controller):
         if not c:
             return 'json:', dict(success=False, message=_("Character with that name not found."))
             
-        if not c in char_list:
+        if not c.name in char_list:
             return 'json:', dict(success=False, message=_("Character with that name is not a member via that method."))
             
         log.info("Removing {0} from group {1} (admitted via {2}) via KICK_MEMBER by {3}".format(c.name, self.group.id, method, user.primary))
-        char_list.remove(c)
+        char_list.remove(c.name)
         self.group.save()
         
         return 'json:', dict(success=True)
@@ -233,10 +233,10 @@ class GroupList(HTTPMethod):
         
     def leave(self, group):
         log.info("Removing {0} from group {1} via LEAVE.".format(user.primary, group.id))
-        if user.primary in group.join_members:
-            group.join_members.remove(user.primary)
-        if user.primary in group.request_members:
-            group.request_members.remove(user.primary)
+        if user.primary.name in group.join_members:
+            group.join_members.remove(user.primary.name)
+        if user.primary.name in group.request_members:
+            group.request_members.remove(user.primary.name)
             
         group.save()
         return 'json:', dict(success=True)
@@ -246,7 +246,7 @@ class GroupList(HTTPMethod):
             return 'json:', dict(success=False, message=_("You do not have permission to join this group."))
         
         log.info("Adding {0} to group {1} via JOIN.".format(user.primary, group.id))
-        group.add_join_member(user.primary)
+        group.add_join_member(user.primary.name)
         
         group.save()
         return 'json:', dict(success=True)
@@ -256,14 +256,14 @@ class GroupList(HTTPMethod):
             return 'json:', dict(success=False, message=_("You do not have permission to request access to this group."))
         
         log.info("Adding {0} to requests list of {1} via REQUEST.".format(user.primary, group.id))
-        group.add_request(user.primary)
+        group.add_request(user.primary.name)
         
         group.save()
         return 'json:', dict(success=True)
         
     def withdraw(self, group):
         log.info("Removing {0} from requests list of {1} via WITHDRAW.".format(user.primary, group.id))
-        group.requests.remove(user.primary)
+        group.requests.remove(user.primary.name)
         
         group.save()
         return 'json:', dict(success=True)

--- a/brave/core/group/template/group.html
+++ b/brave/core/group/template/group.html
@@ -314,8 +314,8 @@ def selected(bool):
                     </thead>
                     <tbody class="sortable">
                         % for char in group.requests:
-                            <tr name="${char.name}">
-                                <td><span onclick="$(this).selectText()">${char.name | h}</span></td>
+                            <tr name="${char}">
+                                <td><span onclick="$(this).selectText()">${char | h}</span></td>
                                 <td style="text-align: center;">
                                     <a class="btn btn-success btn-small acceptRequest" href="#" title="${_('Approve Request')}" rel="tooltip" data-placement="bottom"><i class="fa fa-check"></i></a>
                                     <a class="btn btn-danger btn-small denyRequest" href="#" title="${_('Deny Request')}" rel="tooltip" data-placement="bottom"><i class="fa fa-times"></i></a>
@@ -349,8 +349,8 @@ def selected(bool):
                     </thead>
                     <tbody class="sortable">
                         % for char in getattr(group, rule_set + "_members"):
-                            <tr name="${char.name}">
-                                <td><span onclick="$(this).selectText()">${char.name | h}</span></td>
+                            <tr name="${char}">
+                                <td><span onclick="$(this).selectText()">${char | h}</span></td>
                                 <td style="text-align: center;">
                                     <a class="btn btn-danger btn-small kickMember" href="#" title="${_('Remove From Group')}" rel="tooltip" data-placement="bottom"><i class="fa fa-times"></i></a>
                                 </td>

--- a/brave/core/group/template/list_groups.html
+++ b/brave/core/group/template/list_groups.html
@@ -106,7 +106,7 @@
                                 <td>
                                 % if g in web.user.primary.groups:
                                     Member
-                                % elif web.user.primary in g.requests:
+                                % elif web.user.primary.name in g.requests:
                                     Request pending
                                 % endif
                                 </td>
@@ -115,7 +115,7 @@
                                     <button class="btn btn-danger btn-small leave"><i class="fa fa-times"></i> Leave Group</button>
                                 % elif g in joinableGroups:
                                     <button class="btn btn-success btn-small join"><i class="fa fa-plus"></i> Join Group</button>
-                                % elif web.user.primary in g.requests:
+                                % elif web.user.primary.name in g.requests:
                                     <button class="btn btn-warning btn-small withdraw"><i class="fa fa-times"></i> Withdraw Request</button>
                                 % elif g in requestableGroups:
                                     <button class="btn btn-success btn-small request"><i class="fa fa-plus"></i> Request Access</button>

--- a/brave/core/scripts/groups_requests_join_migration.py
+++ b/brave/core/scripts/groups_requests_join_migration.py
@@ -1,0 +1,41 @@
+from mongoengine import Document, EmbeddedDocument, EmbeddedDocumentField, StringField, EmailField, URLField, DateTimeField, BooleanField, ReferenceField, ListField, IntField
+from brave.core.group.acl import ACLRule
+from brave.core.character.model import EVECharacter
+from datetime import datetime
+from brave.core.permission.model import Permission
+
+class Group(Document):
+    meta = dict(
+            collection = 'Groups',
+            allow_inheritance = False,
+            indexes = [],
+        )
+    
+    id = StringField(db_field='_id', primary_key=True)
+    title = StringField(db_field='t')
+    rules = ListField(EmbeddedDocumentField(ACLRule), db_field='r')
+    join_rules = ListField(EmbeddedDocumentField(ACLRule), db_field='j', default=list)
+    request_rules = ListField(EmbeddedDocumentField(ACLRule), db_field='q', default=list)
+
+    join_members = ListField(StringField(), db_field='jmn', default=list)
+    request_members = ListField(StringField(), db_field='rmn', default=list)
+    requests = ListField(StringField(), db_field='rln', default=list)
+
+    join_members_depr = ListField(ReferenceField(EVECharacter), db_field='jm', default=list)
+    request_members_depr = ListField(ReferenceField(EVECharacter), db_field='rm', default=list)
+    requests_depr = ListField(ReferenceField(EVECharacter), db_field='rl', default=list)
+    
+    creator = ReferenceField('User', db_field='c')
+    modified = DateTimeField(db_field='m', default=datetime.utcnow)
+    _permissions = ListField(ReferenceField(Permission), db_field='p')
+
+def migrate_groups(dry_run=True):
+    m = 0
+    for g in Group.objects:
+        g.join_members = [c.name for c in g.join_members_depr]
+        g.request_members = [c.name for c in g.request_members_depr]
+        g.requests = [c.name for c in g.requests_depr]
+        if not dry_run:
+            g.save()
+        m += 1
+    print "{} groups migrated.".format(m)


### PR DESCRIPTION
Joinable and requestable groups had significantly longer execution
times for Group.evaluate prior to this change, as we were
dereferencing the entire join_members and request_members lists from
the database when all we needed to do was check if the user was in it.
We switch to storing only the character names, which are guaranteed to
be unique, and which doesn't require expensive dereferencing while
still meeting all of our intended use cases (being able to easily check
if a character is in the list).

Signed-off-by: Tyler O'Meara Tyler@TylerOMeara.com
