### PR TITLE
Remove key expiry since MongoDB doesn't clean up

### DIFF
--- a/brave/core/key/model.py
+++ b/brave/core/key/model.py
@@ -26,8 +26,6 @@ class EVECredential(Document):
             allow_inheritance = False,
             indexes = [
                     'owner',
-                    # Don't keep expired credentials.
-                    dict(fields=['expires'], expireAfterSeconds=0),
                     dict(fields=['key'], unique=True)
                 ],
         )


### PR DESCRIPTION
No need to actually clear out expired keys since users can extend their expiry.
