### PR TITLE
cap version of WebCore in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                 'marrow.tags',
                 'marrow.templating',
                 'braveapi',
-                'WebCore>=1.1.2',
+                'WebCore>=1.1.2,<2',
                 'MongoEngine>=0.8,<0.9',
                 'pymongo>=2,<3',
                 'Mako>=0.4.1',


### PR DESCRIPTION
as reminded in #408 - capping WebCore version to be lower than 2 until we update our app to be compatible with the new version
